### PR TITLE
CG-0MLYGKRXS1SJTIU7: Generalize Deck and Pile to support custom card types

### DIFF
--- a/src/card-system/Deck.ts
+++ b/src/card-system/Deck.ts
@@ -42,10 +42,16 @@ export function createDeckFrom(
  *
  * @returns The same array reference (mutated).
  */
-export function shuffle(
-  deck: Card[],
-  rng: () => number = Math.random,
-): Card[] {
+/**
+ * Generic Fisher-Yates shuffle that operates on any array of T.
+ *
+ * An optional random number generator can be supplied for
+ * deterministic testing. The generator must return a value
+ * in [0, 1) (same contract as Math.random).
+ *
+ * @returns The same array reference (mutated).
+ */
+export function shuffle<T>(deck: T[], rng: () => number = Math.random): T[] {
   for (let i = deck.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1));
     [deck[i], deck[j]] = [deck[j], deck[i]];
@@ -59,7 +65,7 @@ export function shuffle(
  * @returns The drawn card, or `undefined` if the deck is empty.
  *          The card is removed from the deck array.
  */
-export function draw(deck: Card[]): Card | undefined {
+export function draw<T>(deck: T[]): T | undefined {
   return deck.pop();
 }
 
@@ -69,7 +75,7 @@ export function draw(deck: Card[]): Card | undefined {
  * Use this when an empty deck indicates a logic error (e.g.
  * dealing should never exhaust the deck).
  */
-export function drawOrThrow(deck: Card[]): Card {
+export function drawOrThrow<T>(deck: T[]): T {
   const card = deck.pop();
   if (card === undefined) {
     throw new Error('Cannot draw from an empty deck');

--- a/src/card-system/Pile.ts
+++ b/src/card-system/Pile.ts
@@ -8,36 +8,35 @@
  * and any other ordered collection of cards in a game.
  */
 
-import { Card } from './Card';
+import type { Card } from './Card';
 
-export class Pile {
-  private readonly cards: Card[];
+/**
+ * Generic Pile abstraction (LIFO) that can contain any T.
+ * Defaults and examples use Card but games may use custom card types.
+ */
+export class Pile<T = Card> {
+  private readonly cards: T[];
 
   /**
-   * Create a Pile, optionally pre-populated with cards.
+   * Create a Pile, optionally pre-populated with items.
    * The last element of the array is treated as the top of the pile.
    */
-  constructor(cards: Card[] = []) {
+  constructor(cards: T[] = []) {
     this.cards = [...cards];
   }
 
-  /** Push one or more cards onto the top of the pile. */
-  push(...newCards: Card[]): void {
+  /** Push one or more items onto the top of the pile. */
+  push(...newCards: T[]): void {
     this.cards.push(...newCards);
   }
 
-  /**
-   * Remove and return the top card.
-   * @returns The top card, or `undefined` if the pile is empty.
-   */
-  pop(): Card | undefined {
+  /** Remove and return the top item, or `undefined` if empty. */
+  pop(): T | undefined {
     return this.cards.pop();
   }
 
-  /**
-   * Remove and return the top card, throwing if the pile is empty.
-   */
-  popOrThrow(): Card {
+  /** Remove and return the top item, throwing if empty. */
+  popOrThrow(): T {
     const card = this.cards.pop();
     if (card === undefined) {
       throw new Error('Cannot pop from an empty pile');
@@ -45,35 +44,27 @@ export class Pile {
     return card;
   }
 
-  /**
-   * Look at the top card without removing it.
-   * @returns The top card, or `undefined` if the pile is empty.
-   */
-  peek(): Card | undefined {
-    return this.cards.length > 0
-      ? this.cards[this.cards.length - 1]
-      : undefined;
+  /** Look at the top item without removing it. */
+  peek(): T | undefined {
+    return this.cards.length > 0 ? this.cards[this.cards.length - 1] : undefined;
   }
 
-  /** Whether the pile contains no cards. */
+  /** Whether the pile contains no items. */
   isEmpty(): boolean {
     return this.cards.length === 0;
   }
 
-  /** The number of cards in the pile. */
+  /** The number of items in the pile. */
   size(): number {
     return this.cards.length;
   }
 
-  /**
-   * Return a shallow copy of all cards in the pile (bottom to top).
-   * Useful for inspection and serialization.
-   */
-  toArray(): Card[] {
+  /** Return a shallow copy of all items (bottom to top). */
+  toArray(): T[] {
     return [...this.cards];
   }
 
-  /** Clear all cards from the pile. */
+  /** Clear all items from the pile. */
   clear(): void {
     this.cards.length = 0;
   }


### PR DESCRIPTION
## Summary\n\nGeneralize the card-system collections to support custom card types so example games can use Deck<T> and Pile<T>.\n\nChanges:\n- src/card-system/Deck.ts: made shuffle/draw/drawOrThrow generic (shuffle<T>, draw<T>, drawOrThrow<T>)\n- src/card-system/Pile.ts: made Pile generic with default type  to preserve backwards compatibility\n\nAcceptance Criteria:\n- Deck and Pile support custom card types.\n- Existing unit tests for card-system pass.\n\nRelated work item: CG-0MLYGKRXS1SJTIU7\n