### PR TITLE
CG-0MLYGKC5Z10X11L1: Extract generic shuffleArray<T> to card-system

### DIFF
--- a/example-games/lost-cities/LostCitiesCards.ts
+++ b/example-games/lost-cities/LostCitiesCards.ts
@@ -233,15 +233,12 @@ export function createLostCitiesDeck(): LostCitiesCard[] {
 /**
  * Fisher-Yates shuffle (in-place) with optional RNG.
  *
+ * Re-exports `shuffleArray` from the shared card-system module,
+ * aliased as `shuffleDeck` for backward compatibility with existing
+ * consumer code.
+ *
  * @returns The same array reference (mutated).
  */
-export function shuffleDeck(
-  deck: LostCitiesCard[],
-  rng: () => number = Math.random,
-): LostCitiesCard[] {
-  for (let i = deck.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
-  }
-  return deck;
-}
+import { shuffleArray } from '../../src/card-system/Deck';
+
+export const shuffleDeck: typeof shuffleArray = shuffleArray;

--- a/example-games/splendor/SplendorCards.ts
+++ b/example-games/splendor/SplendorCards.ts
@@ -104,13 +104,11 @@ export interface NobleTile {
 // Deck / shuffle utilities
 // ---------------------------------------------------------------------------
 
-export function shuffleArray<T>(arr: T[], rng: () => number = Math.random): T[] {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr;
-}
+import { shuffleArray } from '../../src/card-system/Deck';
+
+// Re-export so existing consumers (tests, other modules) can still import
+// shuffleArray from this file without breaking.
+export { shuffleArray } from '../../src/card-system/Deck';
 
 // ---------------------------------------------------------------------------
 // Token supply initialization

--- a/example-games/sushi-go/SushiGoCards.ts
+++ b/example-games/sushi-go/SushiGoCards.ts
@@ -198,17 +198,14 @@ export function createSushiGoDeck(): SushiGoCard[] {
 
 /**
  * Fisher-Yates shuffle (in-place) with optional RNG.
+ *
+ * Re-exports `shuffleArray` from the shared card-system module,
+ * aliased as `shuffleDeck` for backward compatibility with existing
+ * consumer code.
  */
-export function shuffleDeck(
-  deck: SushiGoCard[],
-  rng: () => number = Math.random,
-): SushiGoCard[] {
-  for (let i = deck.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
-  }
-  return deck;
-}
+import { shuffleArray } from '../../src/card-system/Deck';
+
+export const shuffleDeck: typeof shuffleArray = shuffleArray;
 
 /**
  * Number of cards dealt per player based on player count.

--- a/src/card-system/Deck.ts
+++ b/src/card-system/Deck.ts
@@ -34,30 +34,31 @@ export function createDeckFrom(
 }
 
 /**
- * Shuffle a deck in place using the Fisher-Yates algorithm.
- *
- * An optional random number generator can be supplied for
- * deterministic testing. The generator must return a value
- * in [0, 1) (same contract as Math.random).
- *
- * @returns The same array reference (mutated).
- */
-/**
  * Generic Fisher-Yates shuffle that operates on any array of T.
  *
  * An optional random number generator can be supplied for
  * deterministic testing. The generator must return a value
  * in [0, 1) (same contract as Math.random).
  *
- * @returns The same array reference (mutated).
+ * @returns The same array reference (mutated in place).
  */
-export function shuffle<T>(deck: T[], rng: () => number = Math.random): T[] {
-  for (let i = deck.length - 1; i > 0; i--) {
+export function shuffleArray<T>(
+  arr: T[],
+  rng: () => number = Math.random,
+): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
+    [arr[i], arr[j]] = [arr[j], arr[i]];
   }
-  return deck;
+  return arr;
 }
+
+/**
+ * Alias for {@link shuffleArray} — kept for backward compatibility.
+ *
+ * @deprecated Prefer `shuffleArray` for clarity in generic contexts.
+ */
+export const shuffle: typeof shuffleArray = shuffleArray;
 
 /**
  * Draw the top card (last element) from a deck.

--- a/src/card-system/index.ts
+++ b/src/card-system/index.ts
@@ -16,6 +16,7 @@ export { RANKS, SUITS, createCard } from './Card';
 export {
   createStandardDeck,
   createDeckFrom,
+  shuffleArray,
   shuffle,
   draw,
   drawOrThrow,

--- a/tests/card-system/Deck.test.ts
+++ b/tests/card-system/Deck.test.ts
@@ -3,6 +3,7 @@ import {
   createStandardDeck,
   createDeckFrom,
   shuffle,
+  shuffleArray,
   draw,
   drawOrThrow,
 } from '../../src/card-system/Deck';
@@ -110,6 +111,56 @@ describe('Deck', () => {
       const order1 = deck1.map((c) => `${c.rank}-${c.suit}`);
       const order2 = deck2.map((c) => `${c.rank}-${c.suit}`);
       expect(order1).toEqual(order2);
+    });
+  });
+
+  describe('shuffleArray', () => {
+    it('should be the same function as shuffle', () => {
+      expect(shuffleArray).toBe(shuffle);
+    });
+
+    it('should work with non-Card arrays (generic)', () => {
+      const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      let seed = 42;
+      const rng = (): number => {
+        seed = (seed * 16807) % 2147483647;
+        return (seed - 1) / 2147483646;
+      };
+
+      const result = shuffleArray(numbers, rng);
+
+      // Returns the same reference
+      expect(result).toBe(numbers);
+      // Preserves all elements
+      expect([...result].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    it('should produce deterministic results with string arrays', () => {
+      const makeRng = (): (() => number) => {
+        let seed = 99;
+        return () => {
+          seed = (seed * 16807) % 2147483647;
+          return (seed - 1) / 2147483646;
+        };
+      };
+
+      const a = shuffleArray(['a', 'b', 'c', 'd', 'e'], makeRng());
+      const b = shuffleArray(['a', 'b', 'c', 'd', 'e'], makeRng());
+      expect(a).toEqual(b);
+    });
+
+    it('should handle empty arrays', () => {
+      const arr: number[] = [];
+      const result = shuffleArray(arr);
+      expect(result).toBe(arr);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle single-element arrays', () => {
+      const arr = [42];
+      const result = shuffleArray(arr);
+      expect(result).toBe(arr);
+      expect(result).toEqual([42]);
     });
   });
 

--- a/tests/card-system/index.test.ts
+++ b/tests/card-system/index.test.ts
@@ -7,6 +7,7 @@ import {
   createStandardDeck,
   createDeckFrom,
   shuffle,
+  shuffleArray,
   draw,
   drawOrThrow,
   Pile,
@@ -32,8 +33,13 @@ describe('card-system barrel exports', () => {
     expect(typeof createStandardDeck).toBe('function');
     expect(typeof createDeckFrom).toBe('function');
     expect(typeof shuffle).toBe('function');
+    expect(typeof shuffleArray).toBe('function');
     expect(typeof draw).toBe('function');
     expect(typeof drawOrThrow).toBe('function');
+  });
+
+  it('shuffle and shuffleArray should be the same function', () => {
+    expect(shuffle).toBe(shuffleArray);
   });
 
   it('should export Pile class', () => {


### PR DESCRIPTION
## Summary

Centralizes the generic Fisher-Yates shuffle into `src/card-system` as `shuffleArray<T>(arr: T[], rng?: () => number): T[]` and eliminates all three duplicate implementations from example games.

**Work Item:** Generic Deck Shuffle (CG-0MLYGKC5Z10X11L1)
**Parent:** Refactor common game utilities into core engine (CG-0MLX8SR0E1S709OW)

## What Changed

### Core Engine (`src/card-system/`)
- **`Deck.ts`**: Renamed `shuffle<T>` to `shuffleArray<T>` as the canonical API. Added `shuffle` as a deprecated backward-compatible alias so existing consumers (Golf, Beleaguered Castle) continue to work without changes.
- **`index.ts`**: Added `shuffleArray` to barrel exports alongside `shuffle`.

### Example Games (de-duplication)
- **Splendor** (`SplendorCards.ts`): Removed local `shuffleArray<T>()` definition, replaced with re-export from `../../src/card-system/Deck`.
- **Lost Cities** (`LostCitiesCards.ts`): Removed local `shuffleDeck()` definition, replaced with `export const shuffleDeck = shuffleArray` alias.
- **Sushi Go** (`SushiGoCards.ts`): Removed local `shuffleDeck()` definition, replaced with `export const shuffleDeck = shuffleArray` alias.

### Tests
- **`tests/card-system/Deck.test.ts`**: Added `shuffleArray` test suite covering identity with `shuffle`, generic non-Card arrays, deterministic string arrays, empty arrays, and single-element arrays (5 new tests).
- **`tests/card-system/index.test.ts`**: Added verification that `shuffleArray` is exported and is the same function as `shuffle`.

## How to Test

```bash
# Run all targeted tests (278 tests, ~5s)
npx vitest run tests/card-system/ tests/splendor/SplendorCards.test.ts tests/lost-cities/lost-cities-cards.test.ts tests/sushi-go/SushiGoCards.test.ts tests/sushi-go/SushiGoGame.test.ts tests/lost-cities/lost-cities-game.test.ts tests/splendor/SplendorGame.test.ts

# Build check
npm run build
```

## Review Focus

- Verify that the `shuffle` → `shuffleArray` rename with backward-compat alias is the right approach vs. keeping both as independent functions.
- Confirm that the thin re-export pattern in game modules (`export const shuffleDeck = shuffleArray`) is acceptable vs. requiring direct imports from `@card-system` at every call site.
- Check that existing consumers (Golf, Beleaguered Castle) using `shuffle` are unaffected.

## Acceptance Criteria Checklist

- [x] `src/card-system` exports `shuffleArray<T>(arr: T[], rng?: () => number): T[]`
- [x] All game-local shuffle implementations removed and replaced with imports
- [x] Unit tests for deterministic shuffling exist and pass
- [x] `grep` for local shuffle implementations in `example-games/` returns only imports to `@card-system`