### PR TITLE
CG-0MLYGKHJH1PVJJ95: Extract shared AI strategy module into src/ai/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This project follows a **spike-driven development** approach: example games are 
 - **Core Engine** (`src/core-engine/`): The foundational framework that provides essential functionalities such as game loop management, state management, rendering helpers, and shared utilities (e.g. deterministic seeded RNG).
 - **Card System** (`src/card-system/`): A flexible system for defining and managing cards, including their attributes, effects, and interactions. Includes abstractions for Card, Deck, Hand, and Pile.
 - **Rule Engine** (`src/rule-engine/`): A component that allows for the creation and enforcement of game rules, enabling complex gameplay mechanics, turn logic, and validation.
+- **AI** (`src/ai/`): Shared AI strategy abstractions and utility functions. Provides `AiStrategyBase` (base interface), `AiPlayer<TStrategy>` (generic player wrapper that binds a strategy to an RNG), `pickRandom<T>()` (uniform random selection), and `pickBest<T>()` (scored selection with random tie-breaking). Game-specific strategies extend the base types.
 - **User Interface** (`src/ui/`): A modular UI system with reusable components (buttons, menus, overlays) that can be customized and extended to fit different card game themes and styles.
 - **Example Games** (`example-games/`): A collection of sample card games built using the engine, demonstrating its capabilities and serving as templates for future game development. Each example game has its own entry point, scenes, and tests.
 
@@ -25,6 +26,8 @@ tableau-card-engine/
 │   │   └── index.ts
 │   ├── rule-engine/       # Rule definitions, validation, turn logic
 │   │   └── index.ts
+│   ├── ai/                # Shared AI strategy abstractions and utilities
+│   │   └── index.ts       # Barrel file / public API
 │   └── ui/                # Reusable UI components
 │       └── index.ts
 ├── example-games/
@@ -90,6 +93,7 @@ The project defines path aliases for engine modules in both `tsconfig.json` and 
 - `@core-engine/*` -> `src/core-engine/*`
 - `@card-system/*` -> `src/card-system/*`
 - `@rule-engine/*` -> `src/rule-engine/*`
+- `@ai/*` -> `src/ai/*`
 - `@ui/*` -> `src/ui/*`
 
 ## Licensing

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -194,6 +194,10 @@ src/
 │   ├── Pile.ts             Pile class (push, pop, peek, isEmpty, size)
 │   └── index.ts            Barrel file / public API
 ├── rule-engine/index.ts    Rule definitions (stub -- game-specific rules live with games)
+├── ai/                     Shared AI strategy abstractions and utilities
+│   ├── AiStrategy.ts       AiStrategyBase interface, AiPlayer<TStrategy> generic base class
+│   ├── AiUtils.ts          pickRandom<T>, pickBest<T> utility functions
+│   └── index.ts            Barrel file / public API
 └── ui/
     ├── GameSelectorScene.ts Game selector landing page (GameEntry, REGISTRY_KEY_GAMES)
     ├── HelpPanel.ts         Reusable help panel component
@@ -263,6 +267,7 @@ public/assets/
 
 tests/
 ├── smoke.test.ts           Toolchain smoke test
+├── ai/                     AiPlayer, pickRandom, pickBest, barrel export tests
 ├── card-system/            Card, Deck, Pile unit tests
 ├── core-engine/            GameState, TurnSequencer, UndoRedoManager, SeededRng unit tests
 ├── golf/                   Golf game unit + integration + browser tests
@@ -284,6 +289,7 @@ The project defines path aliases in both `tsconfig.json` and `vite.config.ts`:
 | `@core-engine/*` | `src/core-engine/*` |
 | `@card-system/*` | `src/card-system/*` |
 | `@rule-engine/*` | `src/rule-engine/*` |
+| `@ai/*` | `src/ai/*` |
 | `@ui/*` | `src/ui/*` |
 
 Usage in code:

--- a/example-games/golf/AiStrategy.ts
+++ b/example-games/golf/AiStrategy.ts
@@ -6,6 +6,8 @@
  *   - RandomStrategy: uniformly random legal action
  *   - GreedyStrategy: minimizes visible score after the move
  *   - AiPlayer: wrapper that binds a strategy and RNG
+ *
+ * Uses shared AI module (`@ai`) for base types and utility functions.
  */
 
 import type { Card } from '../../src/card-system/Card';
@@ -20,16 +22,15 @@ import type {
   GolfAction,
 } from './GolfGame';
 import { enumerateLegalMoves, enumerateDrawSources } from './GolfGame';
+import type { AiStrategyBase } from '../../src/ai';
+import { AiPlayer as AiPlayerBase, pickRandom } from '../../src/ai';
 
 // ── Strategy interface ──────────────────────────────────────
 
 /**
  * An AI strategy chooses a GolfAction given the current state.
  */
-export interface AiStrategy {
-  /** Human-readable strategy name. */
-  readonly name: string;
-
+export interface AiStrategy extends AiStrategyBase {
   /**
    * Choose an action (draw source + move) for the current player.
    *
@@ -58,14 +59,13 @@ export const RandomStrategy: AiStrategy = {
     shared: GolfSharedState,
     rng: () => number,
   ): GolfAction {
-    const drawSources = enumerateDrawSources(shared);
-    const drawSource = drawSources[Math.floor(rng() * drawSources.length)];
+    const drawSource = pickRandom(enumerateDrawSources(shared), rng);
 
     const legalMoves = enumerateLegalMoves(playerState.grid);
     if (legalMoves.length === 0) {
       throw new Error('No legal moves available');
     }
-    const move = legalMoves[Math.floor(rng() * legalMoves.length)];
+    const move = pickRandom(legalMoves, rng);
 
     return { drawSource, move };
   },
@@ -143,7 +143,7 @@ export const GreedyStrategy: AiStrategy = {
     const best = candidates.filter((c) => c.score === minScore);
 
     // Break ties randomly
-    const chosen = best[Math.floor(rng() * best.length)];
+    const chosen = pickRandom(best, rng);
     return { drawSource: chosen.drawSource, move: chosen.move };
   },
 };
@@ -176,16 +176,11 @@ function simulateMoveScore(
 
 /**
  * An AI player that wraps a strategy and RNG for convenient use.
+ *
+ * Extends the shared {@link AiPlayerBase} to inherit strategy
+ * binding and the `strategyName` getter.
  */
-export class AiPlayer {
-  readonly strategy: AiStrategy;
-  private readonly rng: () => number;
-
-  constructor(strategy: AiStrategy, rng: () => number = Math.random) {
-    this.strategy = strategy;
-    this.rng = rng;
-  }
-
+export class AiPlayer extends AiPlayerBase<AiStrategy> {
   /**
    * Choose an action for the current game state.
    */

--- a/example-games/lost-cities/AiStrategy.ts
+++ b/example-games/lost-cities/AiStrategy.ts
@@ -9,6 +9,8 @@
  *  - GreedyStrategy: prefers extending committed expeditions, avoids
  *    discarding cards the opponent has been collecting (inferred from
  *    visible expedition lanes and discard-pile draw history)
+ *
+ * Uses shared AI module (`@ai`) for base types and utility functions.
  */
 
 import type {
@@ -29,13 +31,14 @@ import {
   getLegalPhase1Actions,
   getLegalPhase2Actions,
 } from './LostCitiesRules';
+import type { AiStrategyBase } from '../../src/ai';
+import { AiPlayer as AiPlayerBase, pickRandom } from '../../src/ai';
 
 // ---------------------------------------------------------------------------
 // Strategy interface
 // ---------------------------------------------------------------------------
 
-export interface LostCitiesAiStrategy {
-  readonly name: string;
+export interface LostCitiesAiStrategy extends AiStrategyBase {
 
   /**
    * Choose a Phase 1 action (play-to-expedition or discard).
@@ -109,7 +112,7 @@ export const RandomStrategy: LostCitiesAiStrategy = {
     if (actions.length === 0) {
       throw new Error('No legal Phase 1 actions available');
     }
-    return actions[Math.floor(rng() * actions.length)];
+    return pickRandom(actions, rng);
   },
 
   choosePhase2(state, rng) {
@@ -117,7 +120,7 @@ export const RandomStrategy: LostCitiesAiStrategy = {
     if (actions.length === 0) {
       throw new Error('No legal Phase 2 actions available');
     }
-    return actions[Math.floor(rng() * actions.length)];
+    return pickRandom(actions, rng);
   },
 };
 
@@ -312,13 +315,14 @@ function greedyChoosePhase2(state: VisibleState): Phase2Action {
 // AI Player class — wraps a strategy + maintains draw history
 // ---------------------------------------------------------------------------
 
-export class LostCitiesAiPlayer {
+export class LostCitiesAiPlayer extends AiPlayerBase<LostCitiesAiStrategy> {
   private drawHistory: OpponentDrawHistory;
 
   constructor(
-    private strategy: LostCitiesAiStrategy = GreedyStrategy,
-    private rng: () => number = Math.random,
+    strategy: LostCitiesAiStrategy = GreedyStrategy,
+    rng: () => number = Math.random,
   ) {
+    super(strategy, rng);
     this.drawHistory = createOpponentDrawHistory();
   }
 
@@ -350,9 +354,5 @@ export class LostCitiesAiPlayer {
   /** Reset draw history (call at start of each round). */
   resetRoundHistory(): void {
     this.drawHistory = createOpponentDrawHistory();
-  }
-
-  get strategyName(): string {
-    return this.strategy.name;
   }
 }

--- a/example-games/splendor/AiStrategy.ts
+++ b/example-games/splendor/AiStrategy.ts
@@ -3,6 +3,8 @@
  *
  * AI opponent strategies for Splendor.
  * All strategies operate on pure game state — no Phaser dependency.
+ *
+ * Uses shared AI module (`@ai`) for base types and utility functions.
  */
 
 import {
@@ -22,13 +24,14 @@ import {
   effectiveCost,
   getAvailableCards,
 } from './SplendorGame';
+import type { AiStrategyBase } from '../../src/ai';
+import { AiPlayer as AiPlayerBase, pickRandom } from '../../src/ai';
 
 // ---------------------------------------------------------------------------
 // Strategy interface
 // ---------------------------------------------------------------------------
 
-export interface SplendorAiStrategy {
-  readonly name: string;
+export interface SplendorAiStrategy extends AiStrategyBase {
   chooseTurn(session: SplendorSession, playerIndex: number, rng: () => number): TurnAction;
   chooseDiscard(
     session: SplendorSession,
@@ -50,7 +53,7 @@ export const RandomStrategy: SplendorAiStrategy = {
     if (actions.length === 0) {
       throw new Error('No legal actions available');
     }
-    return actions[Math.floor(rng() * actions.length)];
+    return pickRandom(actions, rng);
   },
 
   chooseDiscard(session, playerIndex, excess, rng) {
@@ -173,7 +176,7 @@ export const GreedyStrategy: SplendorAiStrategy = {
     }
 
     // Fallback: random action
-    return actions[Math.floor(rng() * actions.length)];
+    return pickRandom(actions, rng);
   },
 
   chooseDiscard(session, playerIndex, excess, _rng) {
@@ -186,11 +189,13 @@ export const GreedyStrategy: SplendorAiStrategy = {
 // AI Player class
 // ---------------------------------------------------------------------------
 
-export class SplendorAiPlayer {
+export class SplendorAiPlayer extends AiPlayerBase<SplendorAiStrategy> {
   constructor(
-    private strategy: SplendorAiStrategy = GreedyStrategy,
-    private rng: () => number = Math.random,
-  ) {}
+    strategy: SplendorAiStrategy = GreedyStrategy,
+    rng: () => number = Math.random,
+  ) {
+    super(strategy, rng);
+  }
 
   chooseTurn(session: SplendorSession, playerIndex: number): TurnAction {
     return this.strategy.chooseTurn(session, playerIndex, this.rng);
@@ -202,10 +207,6 @@ export class SplendorAiPlayer {
     excess: number,
   ): TokenDiscard {
     return this.strategy.chooseDiscard(session, playerIndex, excess, this.rng);
-  }
-
-  get strategyName(): string {
-    return this.strategy.name;
   }
 }
 

--- a/example-games/sushi-go/AiStrategy.ts
+++ b/example-games/sushi-go/AiStrategy.ts
@@ -6,6 +6,8 @@
  *   - RandomStrategy: uniformly random legal card pick
  *   - GreedyStrategy: evaluates each card by expected point value
  *   - SushiGoAiPlayer: wrapper binding strategy and RNG
+ *
+ * Uses shared AI module (`@ai`) for base types and utility functions.
  */
 
 import type { SushiGoCard } from './SushiGoCards';
@@ -13,11 +15,12 @@ import type { SushiGoPlayerState, PickAction } from './SushiGoGame';
 import {
   scoreTableau,
 } from './SushiGoScoring';
+import type { AiStrategyBase } from '../../src/ai';
+import { AiPlayer as AiPlayerBase, pickRandom } from '../../src/ai';
 
 // ── Strategy interface ──────────────────────────────────────
 
-export interface SushiGoAiStrategy {
-  readonly name: string;
+export interface SushiGoAiStrategy extends AiStrategyBase {
 
   /**
    * Choose which card to pick from the hand.
@@ -156,7 +159,7 @@ export const GreedyStrategy: SushiGoAiStrategy = {
           const bestPairs = pairCandidates.filter(
             (c) => c.marginalScore === maxPairMarginal,
           );
-          const chosenPair = bestPairs[Math.floor(rng() * bestPairs.length)];
+          const chosenPair = pickRandom(bestPairs, rng);
           return {
             cardIndex: chosenPair.firstIndex,
             secondCardIndex: chosenPair.secondIndex,
@@ -166,7 +169,7 @@ export const GreedyStrategy: SushiGoAiStrategy = {
     }
 
     // Fall back to best single card
-    const chosen = bestSingles[Math.floor(rng() * bestSingles.length)];
+    const chosen = pickRandom(bestSingles, rng);
     return { cardIndex: chosen.index };
   },
 };
@@ -175,17 +178,16 @@ export const GreedyStrategy: SushiGoAiStrategy = {
 
 /**
  * Wrapper that binds a strategy and RNG for convenient use.
+ *
+ * Extends the shared {@link AiPlayerBase} to inherit strategy
+ * binding and the `strategyName` getter.
  */
-export class SushiGoAiPlayer {
-  readonly strategy: SushiGoAiStrategy;
-  private readonly rng: () => number;
-
+export class SushiGoAiPlayer extends AiPlayerBase<SushiGoAiStrategy> {
   constructor(
     strategy: SushiGoAiStrategy = GreedyStrategy,
     rng: () => number = Math.random,
   ) {
-    this.strategy = strategy;
-    this.rng = rng;
+    super(strategy, rng);
   }
 
   /**

--- a/src/ai/AiStrategy.ts
+++ b/src/ai/AiStrategy.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared AI Strategy abstractions
+ *
+ * Provides the base interface and generic player wrapper used by all
+ * example games.  Game-specific strategy interfaces extend
+ * {@link AiStrategyBase} with their own decision methods.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Strategy base
+// ---------------------------------------------------------------------------
+
+/**
+ * Base constraint for any AI strategy.
+ *
+ * Every game-specific strategy interface should extend this.  The only
+ * requirement is a human-readable `name` used for display and logging.
+ *
+ * @example
+ * ```ts
+ * interface MyGameStrategy extends AiStrategyBase {
+ *   chooseMove(state: MyState, rng: () => number): MyAction;
+ * }
+ * ```
+ */
+export interface AiStrategyBase {
+  readonly name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Generic AI player wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Generic AI player that binds a strategy to an RNG source.
+ *
+ * Game-specific player classes extend this and expose decision methods
+ * that delegate to the strategy while hiding the `rng` parameter from
+ * callers.
+ *
+ * @typeParam TStrategy - The game-specific strategy interface.
+ *
+ * @example
+ * ```ts
+ * class MyAiPlayer extends AiPlayer<MyGameStrategy> {
+ *   chooseMove(state: MyState): MyAction {
+ *     return this.strategy.chooseMove(state, this.rng);
+ *   }
+ * }
+ * ```
+ */
+export class AiPlayer<TStrategy extends AiStrategyBase> {
+  readonly strategy: TStrategy;
+  protected readonly rng: () => number;
+
+  constructor(strategy: TStrategy, rng: () => number = Math.random) {
+    this.strategy = strategy;
+    this.rng = rng;
+  }
+
+  /** Human-readable name of the current strategy. */
+  get strategyName(): string {
+    return this.strategy.name;
+  }
+}

--- a/src/ai/AiUtils.ts
+++ b/src/ai/AiUtils.ts
@@ -1,0 +1,81 @@
+/**
+ * AI decision-making utilities
+ *
+ * Common helper functions extracted from game-specific AI strategies.
+ * These eliminate repeated logic for random selection and greedy
+ * best-pick-with-tiebreaker patterns.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Random selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick a uniformly random element from a non-empty array.
+ *
+ * This is the fundamental building block of every `RandomStrategy`:
+ * enumerate legal actions, then `pickRandom(actions, rng)`.
+ *
+ * @throws Error if `items` is empty.
+ *
+ * @example
+ * ```ts
+ * const action = pickRandom(getLegalActions(state), rng);
+ * ```
+ */
+export function pickRandom<T>(items: readonly T[], rng: () => number): T {
+  if (items.length === 0) {
+    throw new Error('Cannot pick from empty array');
+  }
+  return items[Math.floor(rng() * items.length)];
+}
+
+// ---------------------------------------------------------------------------
+// Greedy / scored selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate each candidate with a scoring function and return the
+ * highest-scoring one.  Ties are broken uniformly at random.
+ *
+ * This is the fundamental building block of every `GreedyStrategy`:
+ * enumerate candidates, provide a domain-specific scoring function,
+ * and let `pickBest` handle the comparison and tie-breaking.
+ *
+ * @param candidates - Non-empty array of candidates.
+ * @param scoreFn    - Returns a numeric score (higher is better).
+ * @param rng        - RNG for tie-breaking.
+ * @throws Error if `candidates` is empty.
+ *
+ * @example
+ * ```ts
+ * const best = pickBest(
+ *   getLegalMoves(state),
+ *   move => evaluateMove(state, move),
+ *   rng,
+ * );
+ * ```
+ */
+export function pickBest<T>(
+  candidates: readonly T[],
+  scoreFn: (candidate: T) => number,
+  rng: () => number,
+): T {
+  if (candidates.length === 0) {
+    throw new Error('No candidates to evaluate');
+  }
+
+  let bestScore = -Infinity;
+  const scored: Array<{ candidate: T; score: number }> = [];
+
+  for (const candidate of candidates) {
+    const score = scoreFn(candidate);
+    scored.push({ candidate, score });
+    if (score > bestScore) bestScore = score;
+  }
+
+  const tied = scored.filter(s => s.score === bestScore);
+  return tied[Math.floor(rng() * tied.length)].candidate;
+}

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,0 +1,9 @@
+/**
+ * AI module barrel file
+ *
+ * @module ai
+ */
+
+export type { AiStrategyBase } from './AiStrategy';
+export { AiPlayer } from './AiStrategy';
+export { pickRandom, pickBest } from './AiUtils';

--- a/tests/ai/AiStrategy.test.ts
+++ b/tests/ai/AiStrategy.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { AiPlayer } from '../../src/ai/AiStrategy';
+import type { AiStrategyBase } from '../../src/ai/AiStrategy';
+import { createSeededRng } from '../../src/core-engine/SeededRng';
+
+// ── Test strategy implementations ───────────────────────────
+
+interface TestStrategy extends AiStrategyBase {
+  chooseAction(options: readonly string[], rng: () => number): string;
+}
+
+const AlwaysFirstStrategy: TestStrategy = {
+  name: 'always-first',
+  chooseAction(options: readonly string[]) {
+    return options[0];
+  },
+};
+
+const RngBasedStrategy: TestStrategy = {
+  name: 'rng-based',
+  chooseAction(options: readonly string[], rng: () => number) {
+    return options[Math.floor(rng() * options.length)];
+  },
+};
+
+// ── Test player subclass ────────────────────────────────────
+
+class TestAiPlayer extends AiPlayer<TestStrategy> {
+  chooseAction(options: readonly string[]): string {
+    return this.strategy.chooseAction(options, this.rng);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+// AiPlayer base class
+// ═══════════════════════════════════════════════════════════
+
+describe('AiPlayer', () => {
+  it('stores the strategy and exposes it via .strategy', () => {
+    const player = new AiPlayer(AlwaysFirstStrategy);
+    expect(player.strategy).toBe(AlwaysFirstStrategy);
+  });
+
+  it('exposes strategyName as a convenience getter', () => {
+    const player = new AiPlayer(AlwaysFirstStrategy);
+    expect(player.strategyName).toBe('always-first');
+  });
+
+  it('defaults rng to Math.random when not provided', () => {
+    const player = new AiPlayer(AlwaysFirstStrategy);
+    // We can't directly inspect the rng, but we can verify it doesn't throw
+    expect(player.strategyName).toBe('always-first');
+  });
+
+  it('accepts a custom rng', () => {
+    const rng = createSeededRng(42);
+    const player = new TestAiPlayer(RngBasedStrategy, rng);
+    const options = ['a', 'b', 'c', 'd', 'e'];
+
+    // Deterministic: same seed produces same results
+    const rng2 = createSeededRng(42);
+    const player2 = new TestAiPlayer(RngBasedStrategy, rng2);
+
+    const results1 = Array.from({ length: 10 }, () => player.chooseAction(options));
+    const results2 = Array.from({ length: 10 }, () => player2.chooseAction(options));
+    expect(results1).toEqual(results2);
+  });
+
+  it('can be subclassed to delegate to strategy methods', () => {
+    const rng = createSeededRng(99);
+    const player = new TestAiPlayer(AlwaysFirstStrategy, rng);
+
+    expect(player.chooseAction(['x', 'y', 'z'])).toBe('x');
+    expect(player.chooseAction(['alpha', 'beta'])).toBe('alpha');
+  });
+
+  it('provides protected rng access to subclasses', () => {
+    const rng = createSeededRng(7);
+    const player = new TestAiPlayer(RngBasedStrategy, rng);
+    const options = ['only'];
+
+    // With a single option, rng-based still returns it
+    expect(player.chooseAction(options)).toBe('only');
+  });
+
+  it('works with different strategy types via generics', () => {
+    // A different strategy shape
+    interface ScoreStrategy extends AiStrategyBase {
+      score(value: number): number;
+    }
+
+    const DoubleStrategy: ScoreStrategy = {
+      name: 'double',
+      score(value: number) {
+        return value * 2;
+      },
+    };
+
+    class ScorePlayer extends AiPlayer<ScoreStrategy> {
+      computeScore(value: number): number {
+        return this.strategy.score(value);
+      }
+    }
+
+    const player = new ScorePlayer(DoubleStrategy);
+    expect(player.strategyName).toBe('double');
+    expect(player.computeScore(21)).toBe(42);
+  });
+});

--- a/tests/ai/AiUtils.test.ts
+++ b/tests/ai/AiUtils.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { pickRandom, pickBest } from '../../src/ai/AiUtils';
+import { createSeededRng } from '../../src/core-engine/SeededRng';
+
+// ═══════════════════════════════════════════════════════════
+// pickRandom
+// ═══════════════════════════════════════════════════════════
+
+describe('pickRandom', () => {
+  it('returns the only element for a single-element array', () => {
+    const rng = createSeededRng(1);
+    expect(pickRandom([42], rng)).toBe(42);
+  });
+
+  it('throws on empty array', () => {
+    const rng = createSeededRng(1);
+    expect(() => pickRandom([], rng)).toThrow('Cannot pick from empty array');
+  });
+
+  it('returns an element from the array', () => {
+    const items = ['a', 'b', 'c', 'd', 'e'];
+    const rng = createSeededRng(7);
+    for (let i = 0; i < 100; i++) {
+      expect(items).toContain(pickRandom(items, rng));
+    }
+  });
+
+  it('uses rng to select (deterministic for same seed)', () => {
+    const items = [10, 20, 30, 40, 50];
+    const rng1 = createSeededRng(42);
+    const rng2 = createSeededRng(42);
+    const seq1 = Array.from({ length: 20 }, () => pickRandom(items, rng1));
+    const seq2 = Array.from({ length: 20 }, () => pickRandom(items, rng2));
+    expect(seq1).toEqual(seq2);
+  });
+
+  it('covers all elements given enough calls', () => {
+    const items = [0, 1, 2, 3, 4];
+    const seen = new Set<number>();
+    const rng = createSeededRng(99);
+    for (let i = 0; i < 500; i++) {
+      seen.add(pickRandom(items, rng));
+    }
+    expect(seen.size).toBe(items.length);
+  });
+
+  it('works with readonly arrays', () => {
+    const items: readonly string[] = ['x', 'y', 'z'];
+    const rng = createSeededRng(1);
+    expect(items).toContain(pickRandom(items, rng));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// pickBest
+// ═══════════════════════════════════════════════════════════
+
+describe('pickBest', () => {
+  it('returns the highest-scoring candidate', () => {
+    const rng = createSeededRng(1);
+    const result = pickBest([1, 5, 3, 2, 4], x => x, rng);
+    expect(result).toBe(5);
+  });
+
+  it('throws on empty candidates', () => {
+    const rng = createSeededRng(1);
+    expect(() => pickBest([], () => 0, rng)).toThrow('No candidates to evaluate');
+  });
+
+  it('breaks ties using rng (deterministic)', () => {
+    // All candidates have equal score
+    const candidates = ['a', 'b', 'c', 'd'];
+    const rng1 = createSeededRng(42);
+    const rng2 = createSeededRng(42);
+    const result1 = pickBest(candidates, () => 1, rng1);
+    const result2 = pickBest(candidates, () => 1, rng2);
+    expect(result1).toBe(result2);
+  });
+
+  it('returns the single candidate when only one exists', () => {
+    const rng = createSeededRng(1);
+    expect(pickBest(['only'], () => 0, rng)).toBe('only');
+  });
+
+  it('uses the scoring function correctly', () => {
+    const items = [
+      { name: 'low', value: 1 },
+      { name: 'high', value: 100 },
+      { name: 'mid', value: 50 },
+    ];
+    const rng = createSeededRng(1);
+    const result = pickBest(items, item => item.value, rng);
+    expect(result.name).toBe('high');
+  });
+
+  it('selects among tied winners (coverage check)', () => {
+    // Two items tied at max score; verify both can be selected
+    const items = ['A', 'B'];
+    const picked = new Set<string>();
+    for (let seed = 1; seed <= 100; seed++) {
+      picked.add(pickBest(items, () => 10, createSeededRng(seed)));
+    }
+    expect(picked.size).toBe(2);
+  });
+
+  it('ignores lower-scoring candidates', () => {
+    const rng = createSeededRng(1);
+    const result = pickBest(
+      [10, 20, 30],
+      x => (x === 30 ? 100 : 0),
+      rng,
+    );
+    expect(result).toBe(30);
+  });
+
+  it('works with negative scores', () => {
+    const rng = createSeededRng(1);
+    const result = pickBest(
+      ['bad', 'worse', 'worst'],
+      (s) => (s === 'bad' ? -1 : s === 'worse' ? -10 : -100),
+      rng,
+    );
+    expect(result).toBe('bad');
+  });
+});

--- a/tests/ai/index.test.ts
+++ b/tests/ai/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+describe('AI module barrel exports', () => {
+  it('exports AiPlayer class', async () => {
+    const mod = await import('../../src/ai/index');
+    expect(mod.AiPlayer).toBeDefined();
+    expect(typeof mod.AiPlayer).toBe('function');
+  });
+
+  it('exports pickRandom function', async () => {
+    const mod = await import('../../src/ai/index');
+    expect(mod.pickRandom).toBeDefined();
+    expect(typeof mod.pickRandom).toBe('function');
+  });
+
+  it('exports pickBest function', async () => {
+    const mod = await import('../../src/ai/index');
+    expect(mod.pickBest).toBeDefined();
+    expect(typeof mod.pickBest).toBe('function');
+  });
+
+  it('AiStrategyBase is usable as a type (compile-time check)', async () => {
+    // AiStrategyBase is exported as `export type`, so it won't appear
+    // as a runtime value. We verify the barrel re-exports AiPlayer
+    // which requires AiStrategyBase to be importable for generics.
+    const mod = await import('../../src/ai/index');
+    const player = new mod.AiPlayer({ name: 'test' });
+    expect(player.strategyName).toBe('test');
+  });
+
+  it('AiPlayer instances work through barrel import', async () => {
+    const { AiPlayer, pickRandom } = await import('../../src/ai/index');
+    const strategy = { name: 'barrel-test' };
+    let callCount = 0;
+    const rng = () => {
+      callCount++;
+      return 0.5;
+    };
+    const player = new AiPlayer(strategy, rng);
+    expect(player.strategyName).toBe('barrel-test');
+
+    // Verify pickRandom also works through barrel
+    const result = pickRandom(['a', 'b', 'c'], rng);
+    expect(['a', 'b', 'c']).toContain(result);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "@core-engine/*": ["src/core-engine/*"],
       "@card-system/*": ["src/card-system/*"],
       "@rule-engine/*": ["src/rule-engine/*"],
-      "@ui/*": ["src/ui/*"]
+      "@ui/*": ["src/ui/*"],
+      "@ai/*": ["src/ai/*"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => ({
       '@card-system': path.resolve(__dirname, 'src/card-system'),
       '@rule-engine': path.resolve(__dirname, 'src/rule-engine'),
       '@ui': path.resolve(__dirname, 'src/ui'),
+      '@ai': path.resolve(__dirname, 'src/ai'),
     },
   },
   build: {


### PR DESCRIPTION
## Summary

- Created `src/ai/` module with `AiStrategyBase` interface, `AiPlayer<TStrategy>` generic base class, `pickRandom<T>()` and `pickBest<T>()` utility functions
- Migrated all 4 games with AI (Golf, Splendor, Sushi Go, Lost Cities) to extend the shared abstractions
- Added `@ai/*` path alias in `tsconfig.json` and `vite.config.ts`
- Added 26 unit tests covering `AiPlayer`, `pickRandom`, `pickBest`, and barrel exports
- Updated `AGENTS.md` and `docs/DEVELOPER.md` with new module documentation

## Details

### New module: `src/ai/`

| File | Contents |
|------|----------|
| `AiStrategy.ts` | `AiStrategyBase` interface (`{ name: string }`), `AiPlayer<TStrategy>` generic base class (binds strategy + RNG) |
| `AiUtils.ts` | `pickRandom<T>(items, rng)` — uniform random selection; `pickBest<T>(items, scoreFn, rng)` — highest-score selection with random tie-breaking |
| `index.ts` | Barrel exports |

### Game migrations

Each game's `AiStrategy.ts` was updated to:
- Extend `AiStrategyBase` for strategy interfaces
- Extend `AiPlayer<TStrategy>` for player wrappers
- Use `pickRandom` for uniform random selections
- Use `pickRandom` for tie-breaking in greedy strategies

All 1020 unit tests pass. Build succeeds.

## Work Item

Closes CG-0MLYGKHJH1PVJJ95 (child of epic CG-0MLX8SR0E1S709OW)