### PR TITLE
CG-0MLYGKJGT0SX6LM5: Extract TranscriptRecorderBase into core-engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This project follows a **spike-driven development** approach: example games are 
 
 ## Components
 
-- **Core Engine** (`src/core-engine/`): The foundational framework that provides essential functionalities such as game loop management, state management, rendering helpers, and shared utilities (e.g. deterministic seeded RNG).
+- **Core Engine** (`src/core-engine/`): The foundational framework that provides essential functionalities such as game loop management, state management, rendering helpers, and shared utilities (e.g. deterministic seeded RNG, `TranscriptRecorderBase<T>` for game transcript recording).
 - **Card System** (`src/card-system/`): A flexible system for defining and managing cards, including their attributes, effects, and interactions. Includes abstractions for Card, Deck, Hand, and Pile.
 - **Rule Engine** (`src/rule-engine/`): A component that allows for the creation and enforcement of game rules, enabling complex gameplay mechanics, turn logic, and validation.
 - **AI** (`src/ai/`): Shared AI strategy abstractions and utility functions. Provides `AiStrategyBase` (base interface), `AiPlayer<TStrategy>` (generic player wrapper that binds a strategy to an RNG), `pickRandom<T>()` (uniform random selection), and `pickBest<T>()` (scored selection with random tie-breaking). Game-specific strategies extend the base types.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -186,6 +186,7 @@ src/
 ├── core-engine/            Game loop, state management, turn sequencing, utilities
 │   ├── GameState.ts        GameState<T>, createGameState
 │   ├── SeededRng.ts        createSeededRng — deterministic PRNG (LCG) for shuffles and AI
+│   ├── TranscriptRecorder.ts BaseTranscript interface, TranscriptRecorderBase<T> abstract base class
 │   ├── TurnSequencer.ts    advanceTurn, getCurrentPlayer, startGame, endGame
 │   └── index.ts            Barrel file / public API
 ├── card-system/            Card, Deck, Pile abstractions
@@ -269,7 +270,7 @@ tests/
 ├── smoke.test.ts           Toolchain smoke test
 ├── ai/                     AiPlayer, pickRandom, pickBest, barrel export tests
 ├── card-system/            Card, Deck, Pile unit tests
-├── core-engine/            GameState, TurnSequencer, UndoRedoManager, SeededRng unit tests
+├── core-engine/            GameState, TurnSequencer, UndoRedoManager, SeededRng, TranscriptRecorder unit tests
 ├── golf/                   Golf game unit + integration + browser tests
 ├── beleaguered-castle/     Beleaguered Castle unit + integration tests
 ├── sushi-go/               Sushi Go! cards, scoring, game, AI tests

--- a/example-games/beleaguered-castle/GameTranscript.ts
+++ b/example-games/beleaguered-castle/GameTranscript.ts
@@ -26,6 +26,7 @@ import type {
 import { FOUNDATION_COUNT, TABLEAU_COUNT } from './BeleagueredCastleState';
 import { snapshotCard } from '../../src/core-engine/TranscriptTypes';
 import type { CardSnapshot } from '../../src/core-engine/TranscriptTypes';
+import { TranscriptRecorderBase } from '../../src/core-engine/TranscriptRecorder';
 
 // Re-export so existing consumers that import from this module still work.
 export { snapshotCard };
@@ -166,11 +167,9 @@ export function snapshotBoard(state: BeleagueredCastleState): BoardSnapshot {
  *   recorder.recordRedo(state.moveCount);
  *   const transcript = recorder.finalize('win', moveCount, elapsed);
  */
-export class BCTranscriptRecorder {
-  private readonly transcript: BCGameTranscript;
-
+export class BCTranscriptRecorder extends TranscriptRecorderBase<BCGameTranscript> {
   constructor(seed: number, initialState: BeleagueredCastleState) {
-    this.transcript = {
+    super({
       version: 1,
       game: 'beleaguered-castle',
       seed,
@@ -179,7 +178,7 @@ export class BCTranscriptRecorder {
       initialState: snapshotBoard(initialState),
       moves: [],
       result: null,
-    };
+    });
   }
 
   /** Record a player-initiated move. */
@@ -234,10 +233,4 @@ export class BCTranscriptRecorder {
     return this.transcript;
   }
 
-  /**
-   * Get the transcript in its current state (may not be finalized).
-   */
-  getTranscript(): BCGameTranscript {
-    return this.transcript;
-  }
 }

--- a/example-games/golf/GameTranscript.ts
+++ b/example-games/golf/GameTranscript.ts
@@ -15,6 +15,7 @@ import type { GolfSession, TurnResult } from './GolfGame';
 import { scoreGrid, scoreVisibleCards } from './GolfScoring';
 import { snapshotCard } from '../../src/core-engine/TranscriptTypes';
 import type { CardSnapshot } from '../../src/core-engine/TranscriptTypes';
+import { TranscriptRecorderBase } from '../../src/core-engine/TranscriptRecorder';
 
 // Re-export so existing consumers that import from this module still work.
 export { snapshotCard };
@@ -126,23 +127,20 @@ export function snapshotBoard(grid: GolfGrid): BoardSnapshot {
  *   // ... after game ends ...
  *   const transcript = recorder.finalize();
  */
-export class TranscriptRecorder {
-  private readonly transcript: GameTranscript;
+export class TranscriptRecorder extends TranscriptRecorderBase<GameTranscript> {
   private readonly session: GolfSession;
 
   constructor(
     session: GolfSession,
     playerStrategies?: Array<string | undefined>,
   ) {
-    this.session = session;
-
     const players = session.gameState.players.map((p, i) => ({
       name: p.name,
       isAI: p.isAI,
       strategy: playerStrategies?.[i],
     }));
 
-    this.transcript = {
+    super({
       version: 1,
       metadata: {
         startedAt: new Date().toISOString(),
@@ -160,7 +158,9 @@ export class TranscriptRecorder {
       },
       turns: [],
       results: null,
-    };
+    });
+
+    this.session = session;
   }
 
   /**
@@ -219,13 +219,6 @@ export class TranscriptRecorder {
       winnerName: this.session.gameState.players[winnerIndex].name,
     };
 
-    return this.transcript;
-  }
-
-  /**
-   * Get the transcript in its current state (may not be finalized).
-   */
-  getTranscript(): GameTranscript {
     return this.transcript;
   }
 }

--- a/example-games/lost-cities/GameTranscript.ts
+++ b/example-games/lost-cities/GameTranscript.ts
@@ -29,6 +29,7 @@ import type {
 import type {
   LostCitiesAction,
 } from './LostCitiesRules';
+import { TranscriptRecorderBase } from '../../src/core-engine/TranscriptRecorder';
 
 // ── Card snapshot ──────────────────────────────────────────
 
@@ -230,8 +231,7 @@ export interface LostCitiesTranscript {
  *   // after match ends:
  *   const transcript = recorder.finalize(session);
  */
-export class LCTranscriptRecorder {
-  private readonly transcript: LostCitiesTranscript;
+export class LCTranscriptRecorder extends TranscriptRecorderBase<LostCitiesTranscript> {
   private currentRound: RoundRecord;
   private actionCounter = 0;
 
@@ -245,13 +245,7 @@ export class LCTranscriptRecorder {
       strategy: playerStrategies?.[i],
     }));
 
-    this.currentRound = {
-      roundNumber: 1,
-      actions: [],
-      scores: null,
-    };
-
-    this.transcript = {
+    super({
       version: 1,
       gameType: 'lost-cities',
       metadata: {
@@ -268,6 +262,12 @@ export class LCTranscriptRecorder {
       },
       rounds: [],
       results: null,
+    });
+
+    this.currentRound = {
+      roundNumber: 1,
+      actions: [],
+      scores: null,
     };
   }
 
@@ -395,8 +395,4 @@ export class LCTranscriptRecorder {
     return this.transcript;
   }
 
-  /** Get the transcript in its current state (may not be finalized). */
-  getTranscript(): LostCitiesTranscript {
-    return this.transcript;
-  }
 }

--- a/src/core-engine/TranscriptRecorder.ts
+++ b/src/core-engine/TranscriptRecorder.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared transcript recorder base types for the Tableau Card Engine.
+ *
+ * Provides a generic `BaseTranscript` interface (recommended shape for
+ * new games) and an abstract `TranscriptRecorderBase<T>` class that all
+ * game-specific transcript recorders extend.
+ *
+ * The base class eliminates the duplicated `getTranscript()` pattern
+ * and provides a protected `transcript` field for subclass access.
+ *
+ * Game-specific recorders provide their own:
+ *  - `recordTurn()` / `recordAction()` / `recordMove()` methods
+ *  - `finalize()` implementation (sets end timestamp and results)
+ *  - Board snapshot and card snapshot types
+ *
+ * @example
+ * ```ts
+ * interface MyTranscript extends BaseTranscript<MyState, MyEvent, MyResult> {
+ *   // game-specific extras
+ * }
+ *
+ * class MyRecorder extends TranscriptRecorderBase<MyTranscript> {
+ *   constructor(session: MySession) {
+ *     super({
+ *       version: 1,
+ *       gameType: 'my-game',
+ *       startedAt: new Date().toISOString(),
+ *       endedAt: '',
+ *       initialState: snapshotBoard(session),
+ *       events: [],
+ *       results: null,
+ *     });
+ *   }
+ *
+ *   finalize(): MyTranscript {
+ *     this.transcript.endedAt = new Date().toISOString();
+ *     this.transcript.results = computeResults();
+ *     return this.getTranscript();
+ *   }
+ * }
+ * ```
+ */
+
+// ── Base transcript shape ──────────────────────────────────
+
+/**
+ * Recommended transcript shape for new games.
+ *
+ * Existing games may use slightly different field names or nesting
+ * (e.g. `turns` instead of `events`, or `metadata.startedAt` instead
+ * of flat `startedAt`).  This interface captures the canonical shape
+ * that new games should follow.
+ *
+ * @typeParam TInitialState - Snapshot of the board before any moves
+ * @typeParam TEvent - A single recorded event (turn, move, action, etc.)
+ * @typeParam TResult - Final game/match results
+ */
+export interface BaseTranscript<TInitialState, TEvent, TResult> {
+  /** Format version for future compatibility. */
+  version: number;
+  /** Game identifier string (e.g. 'golf', 'beleaguered-castle'). */
+  gameType: string;
+  /** ISO 8601 timestamp when the game started. */
+  startedAt: string;
+  /** ISO 8601 timestamp when the game ended (empty string until finalized). */
+  endedAt: string;
+  /** Board state snapshot before any moves/actions. */
+  initialState: TInitialState;
+  /** Ordered list of recorded events (turns, moves, actions). */
+  events: TEvent[];
+  /** Final results, or null while the game is in progress. */
+  results: TResult | null;
+}
+
+// ── Abstract recorder base ─────────────────────────────────
+
+/**
+ * Abstract base class for game transcript recorders.
+ *
+ * Provides the common `getTranscript()` accessor and a protected
+ * `transcript` field.  Subclasses must call `super()` with a fully
+ * initialized transcript object.
+ *
+ * The class is deliberately minimal: it does not prescribe how
+ * events are recorded, how timestamps are managed, or how results
+ * are computed, since these vary across games.  It extracts only
+ * the truly common pattern: holding a transcript object and
+ * exposing it via `getTranscript()`.
+ *
+ * @typeParam T - The concrete transcript type for this game
+ */
+export abstract class TranscriptRecorderBase<T> {
+  protected readonly transcript: T;
+
+  /**
+   * @param transcript - A fully initialized transcript object.
+   *                     Typically has `endedAt` set to `''` and
+   *                     `results` set to `null`.
+   */
+  constructor(transcript: T) {
+    this.transcript = transcript;
+  }
+
+  /**
+   * Get the transcript in its current state (may not be finalized).
+   *
+   * This is identical across all game recorders and is the primary
+   * reason for the base class.
+   */
+  getTranscript(): T {
+    return this.transcript;
+  }
+}

--- a/src/core-engine/index.ts
+++ b/src/core-engine/index.ts
@@ -63,6 +63,10 @@ export { GameEventEmitter } from './GameEventEmitter';
 export type { CardSnapshot } from './TranscriptTypes';
 export { snapshotCard } from './TranscriptTypes';
 
+// Shared transcript recorder base
+export type { BaseTranscript } from './TranscriptRecorder';
+export { TranscriptRecorderBase } from './TranscriptRecorder';
+
 // Phaser event bridge
 export type { PhaserLikeEventEmitter } from './PhaserEventBridge';
 export { PhaserEventBridge } from './PhaserEventBridge';

--- a/tests/core-engine/TranscriptRecorder.test.ts
+++ b/tests/core-engine/TranscriptRecorder.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the shared TranscriptRecorderBase class and
+ * BaseTranscript interface from src/core-engine/TranscriptRecorder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TranscriptRecorderBase,
+  type BaseTranscript,
+} from '../../src/core-engine/TranscriptRecorder';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+/** Simple board state for tests. */
+interface TestState {
+  board: string[];
+}
+
+/** Simple event for tests. */
+interface TestEvent {
+  action: string;
+  value: number;
+}
+
+/** Simple result for tests. */
+interface TestResult {
+  winner: string;
+  score: number;
+}
+
+/** Concrete transcript type using BaseTranscript. */
+type TestTranscript = BaseTranscript<TestState, TestEvent, TestResult>;
+
+/** Concrete recorder subclass for tests. */
+class TestRecorder extends TranscriptRecorderBase<TestTranscript> {
+  constructor(gameType = 'test-game', initialState?: TestState) {
+    super({
+      version: 1,
+      gameType,
+      startedAt: new Date().toISOString(),
+      endedAt: '',
+      initialState: initialState ?? { board: ['a', 'b', 'c'] },
+      events: [],
+      results: null,
+    });
+  }
+
+  /** Expose addEvent for testing. */
+  addEvent(event: TestEvent): void {
+    this.transcript.events.push(event);
+  }
+
+  /** Expose finalize for testing. */
+  finalize(winner: string, score: number): TestTranscript {
+    this.transcript.endedAt = new Date().toISOString();
+    this.transcript.results = { winner, score };
+    return this.getTranscript();
+  }
+}
+
+/**
+ * A custom transcript type that does NOT extend BaseTranscript,
+ * demonstrating that the base class works with any shape.
+ */
+interface CustomTranscript {
+  version: 1;
+  game: string;
+  metadata: { startedAt: string; endedAt: string };
+  turns: Array<{ move: string }>;
+  result: { outcome: string } | null;
+}
+
+/** Recorder for the custom transcript shape. */
+class CustomRecorder extends TranscriptRecorderBase<CustomTranscript> {
+  constructor() {
+    super({
+      version: 1,
+      game: 'custom-game',
+      metadata: {
+        startedAt: new Date().toISOString(),
+        endedAt: '',
+      },
+      turns: [],
+      result: null,
+    });
+  }
+
+  recordTurn(move: string): void {
+    this.transcript.turns.push({ move });
+  }
+
+  finalize(outcome: string): CustomTranscript {
+    this.transcript.metadata.endedAt = new Date().toISOString();
+    this.transcript.result = { outcome };
+    return this.getTranscript();
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('TranscriptRecorderBase', () => {
+  describe('constructor', () => {
+    it('should store the provided transcript', () => {
+      const recorder = new TestRecorder('my-game');
+      const t = recorder.getTranscript();
+      expect(t.version).toBe(1);
+      expect(t.gameType).toBe('my-game');
+    });
+
+    it('should initialize with empty events and null results', () => {
+      const recorder = new TestRecorder();
+      const t = recorder.getTranscript();
+      expect(t.events).toEqual([]);
+      expect(t.results).toBeNull();
+    });
+
+    it('should capture the initial state', () => {
+      const state: TestState = { board: ['x', 'y'] };
+      const recorder = new TestRecorder('game', state);
+      expect(recorder.getTranscript().initialState).toEqual({
+        board: ['x', 'y'],
+      });
+    });
+
+    it('should set startedAt to a valid ISO timestamp', () => {
+      const recorder = new TestRecorder();
+      const t = recorder.getTranscript();
+      expect(t.startedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
+    });
+
+    it('should set endedAt to empty string', () => {
+      const recorder = new TestRecorder();
+      expect(recorder.getTranscript().endedAt).toBe('');
+    });
+  });
+
+  describe('getTranscript()', () => {
+    it('should return the same object on repeated calls', () => {
+      const recorder = new TestRecorder();
+      const t1 = recorder.getTranscript();
+      const t2 = recorder.getTranscript();
+      expect(t1).toBe(t2);
+    });
+
+    it('should reflect events added after construction', () => {
+      const recorder = new TestRecorder();
+      recorder.addEvent({ action: 'move', value: 42 });
+      const t = recorder.getTranscript();
+      expect(t.events).toHaveLength(1);
+      expect(t.events[0]).toEqual({ action: 'move', value: 42 });
+    });
+  });
+
+  describe('finalize() pattern', () => {
+    it('should set results and endedAt', () => {
+      const recorder = new TestRecorder();
+      recorder.addEvent({ action: 'play', value: 1 });
+      const t = recorder.finalize('Alice', 100);
+
+      expect(t.results).toEqual({ winner: 'Alice', score: 100 });
+      expect(t.endedAt).not.toBe('');
+    });
+
+    it('should return the same transcript object', () => {
+      const recorder = new TestRecorder();
+      const finalized = recorder.finalize('Bob', 50);
+      expect(finalized).toBe(recorder.getTranscript());
+    });
+
+    it('should preserve events recorded before finalization', () => {
+      const recorder = new TestRecorder();
+      recorder.addEvent({ action: 'a', value: 1 });
+      recorder.addEvent({ action: 'b', value: 2 });
+      recorder.addEvent({ action: 'c', value: 3 });
+      const t = recorder.finalize('Charlie', 75);
+
+      expect(t.events).toHaveLength(3);
+      expect(t.events.map((e) => e.action)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('BaseTranscript type conformance', () => {
+    it('should satisfy BaseTranscript shape', () => {
+      const recorder = new TestRecorder('conformance-test');
+      const t: BaseTranscript<TestState, TestEvent, TestResult> =
+        recorder.getTranscript();
+
+      expect(t.version).toBe(1);
+      expect(t.gameType).toBe('conformance-test');
+      expect(typeof t.startedAt).toBe('string');
+      expect(t.endedAt).toBe('');
+      expect(t.initialState).toBeDefined();
+      expect(Array.isArray(t.events)).toBe(true);
+      expect(t.results).toBeNull();
+    });
+  });
+
+  describe('serialization round-trip', () => {
+    it('should produce JSON-serializable transcripts', () => {
+      const recorder = new TestRecorder();
+      recorder.addEvent({ action: 'draw', value: 5 });
+      recorder.finalize('Dana', 42);
+
+      const json = JSON.stringify(recorder.getTranscript());
+      const parsed = JSON.parse(json) as TestTranscript;
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.gameType).toBe('test-game');
+      expect(parsed.events).toHaveLength(1);
+      expect(parsed.results).toEqual({ winner: 'Dana', score: 42 });
+    });
+  });
+});
+
+describe('custom transcript shape (non-BaseTranscript)', () => {
+  it('should work with a transcript type that does not extend BaseTranscript', () => {
+    const recorder = new CustomRecorder();
+    const t = recorder.getTranscript();
+    expect(t.version).toBe(1);
+    expect(t.game).toBe('custom-game');
+    expect(t.turns).toEqual([]);
+    expect(t.result).toBeNull();
+  });
+
+  it('should record turns into the custom shape', () => {
+    const recorder = new CustomRecorder();
+    recorder.recordTurn('draw');
+    recorder.recordTurn('play');
+    const t = recorder.getTranscript();
+    expect(t.turns).toHaveLength(2);
+    expect(t.turns[0].move).toBe('draw');
+    expect(t.turns[1].move).toBe('play');
+  });
+
+  it('should finalize with the custom shape', () => {
+    const recorder = new CustomRecorder();
+    recorder.recordTurn('draw');
+    const t = recorder.finalize('win');
+    expect(t.result).toEqual({ outcome: 'win' });
+    expect(t.metadata.endedAt).not.toBe('');
+  });
+});
+
+describe('barrel exports', () => {
+  it('should export TranscriptRecorderBase from core-engine index', async () => {
+    const mod = await import('../../src/core-engine/index');
+    expect(mod.TranscriptRecorderBase).toBeDefined();
+    expect(typeof mod.TranscriptRecorderBase).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `TranscriptRecorderBase<T>` abstract base class and `BaseTranscript<TInitialState, TEvent, TResult>` interface to `src/core-engine/`
- Migrates all 3 game transcript recorders (Golf, Beleaguered Castle, Lost Cities) to extend the base class
- Eliminates duplicated `getTranscript()` method and `private readonly transcript` field across all games

## Design Decisions

- **Unconstrained generic `T`**: The base class uses `TranscriptRecorderBase<T>` (not `T extends BaseTranscript`) because existing games use different field names (`moves` vs `rounds`, `game` vs `gameType`) and nesting patterns (`metadata.startedAt` vs flat `startedAt`)
- **`BaseTranscript` as recommended shape**: Provided as guidance for new games but existing games are not forced to conform
- **No `setEndTimestamp()` in base**: Timestamp location differs across games (nested vs flat), so this stays game-specific

## Changes

| File | Change |
|------|--------|
| `src/core-engine/TranscriptRecorder.ts` | New: `BaseTranscript` interface + `TranscriptRecorderBase<T>` class |
| `src/core-engine/index.ts` | Added barrel exports |
| `tests/core-engine/TranscriptRecorder.test.ts` | 16 new tests |
| `example-games/golf/GameTranscript.ts` | Extends `TranscriptRecorderBase`, removed `getTranscript()` + field |
| `example-games/beleaguered-castle/GameTranscript.ts` | Extends `TranscriptRecorderBase`, removed `getTranscript()` |
| `example-games/lost-cities/GameTranscript.ts` | Extends `TranscriptRecorderBase`, removed `getTranscript()` + field |
| `AGENTS.md` | Updated core-engine description |
| `docs/DEVELOPER.md` | Added `TranscriptRecorder.ts` to project structure |

## Testing

- All 1036 unit tests pass (50 test files)
- `npm run build` succeeds
- Pre-existing browser test timeouts unaffected