### PR TITLE
Move Beleaguered Castle tableau columns down by 1/3 card height

### DIFF
--- a/example-games/beleaguered-castle/scenes/BeleagueredCastleScene.ts
+++ b/example-games/beleaguered-castle/scenes/BeleagueredCastleScene.ts
@@ -95,7 +95,7 @@ const TITLE_Y = 20;
 const FOUNDATION_Y = 95;
 
 /** Tableau starts below the foundations (with room for suit labels). */
-const TABLEAU_TOP_Y = 240;
+const TABLEAU_TOP_Y = 282;
 
 /** Z-depth for a card being dragged. */
 const DRAG_DEPTH = 1000;


### PR DESCRIPTION
## Summary

- Moved TABLEAU_TOP_Y from 240 to 282 (+42px, approximately 1/3 of 126px card height) to add more visual breathing room between the foundation row and the tableau columns

## Work Item

CG-0MLYRMOZ80QNQO0Z (follow-up adjustment)

## Testing

- All 1036 unit tests pass
- Build succeeds