### PR TITLE
CG-0MLZSJHGL1A02AQD: SVG Card Template & Runtime Rendering for The Mind

### DIFF
--- a/example-games/the-mind/MindCardRenderer.ts
+++ b/example-games/the-mind/MindCardRenderer.ts
@@ -1,0 +1,100 @@
+/**
+ * Mind Card Renderer
+ *
+ * Provides utilities for loading and displaying Mind card SVG assets
+ * in a Phaser scene. Cards are pre-generated SVGs (one per value 1-100
+ * plus a card back) stored in `public/assets/cards/the-mind/`.
+ *
+ * This module follows the same pattern as CardTextureHelpers.ts but is
+ * specific to The Mind's numbered card type (MindCard).
+ */
+
+import type { MindCard } from './MindCard';
+import { cardAssetKey, CARD_BACK_KEY, MIN_VALUE, MAX_VALUE } from './MindCard';
+
+// ── Constants ──────────────────────────────────────────────
+
+/** Default card sprite width in pixels (matches SVG source at 140px). */
+export const MIND_CARD_W = 48;
+
+/** Default card sprite height in pixels (matches SVG source at 190px). */
+export const MIND_CARD_H = 65;
+
+/** Base path to The Mind card SVG assets (relative to Vite public dir). */
+const ASSET_PATH = 'assets/cards/the-mind';
+
+// ── Texture key helpers ────────────────────────────────────
+
+/**
+ * Return the Phaser texture key for a MindCard, taking faceUp state
+ * into account. Face-down cards return the card back key.
+ *
+ * @param card  The MindCard to get a texture key for.
+ * @returns     The texture key string (e.g. `'mind-42'` or `'mind-back'`).
+ * @throws      Error if card value is outside the valid range (1-100).
+ */
+export function getMindCardTexture(card: MindCard): string {
+  if (!card.faceUp) return CARD_BACK_KEY;
+  validateValue(card.value);
+  return cardAssetKey(card);
+}
+
+/**
+ * Return the Phaser texture key for a Mind card value.
+ *
+ * @param value  Card value (1-100).
+ * @returns      The texture key string (e.g. `'mind-42'`).
+ * @throws       Error if value is outside the valid range (1-100).
+ */
+export function mindCardTextureKey(value: number): string {
+  validateValue(value);
+  return `mind-${value}`;
+}
+
+// ── Preloading ─────────────────────────────────────────────
+
+/**
+ * Preload all 100 Mind card face SVGs and the card back SVG into a
+ * Phaser scene's texture manager.
+ *
+ * Call this from your scene's `preload()` method. Once loaded, textures
+ * are cached in Phaser's texture manager and won't be re-loaded on
+ * subsequent calls.
+ *
+ * @param scene   The Phaser scene whose loader should be used.
+ * @param width   Card sprite width in pixels (defaults to `MIND_CARD_W`).
+ * @param height  Card sprite height in pixels (defaults to `MIND_CARD_H`).
+ */
+export function preloadMindCardAssets(
+  scene: Phaser.Scene,
+  width: number = MIND_CARD_W,
+  height: number = MIND_CARD_H,
+): void {
+  // Card back
+  scene.load.svg(CARD_BACK_KEY, `${ASSET_PATH}/mind-back.svg`, {
+    width,
+    height,
+  });
+
+  // All 100 numbered card faces
+  for (let value = MIN_VALUE; value <= MAX_VALUE; value++) {
+    const key = `mind-${value}`;
+    scene.load.svg(key, `${ASSET_PATH}/${key}.svg`, { width, height });
+  }
+}
+
+// ── Validation ─────────────────────────────────────────────
+
+/**
+ * Validate that a card value is within the allowed range (1-100).
+ *
+ * @param value  The card value to validate.
+ * @throws       Error if value is outside 1-100 (inclusive).
+ */
+function validateValue(value: number): void {
+  if (value < MIN_VALUE || value > MAX_VALUE || !Number.isInteger(value)) {
+    throw new Error(
+      `Invalid Mind card value: ${value}. Must be an integer between ${MIN_VALUE} and ${MAX_VALUE}.`,
+    );
+  }
+}

--- a/public/assets/CREDITS.md
+++ b/public/assets/CREDITS.md
@@ -102,3 +102,16 @@ Files (in `audio/lost-cities/`):
 - `match-lose.wav` — sandstorm loss on match defeat
 - `score-reveal.wav` — artifact chimes when scores are displayed
 - `ui-click.wav` — map pin click for UI button presses
+
+## The Mind Card Assets
+
+101 SVG card images (100 numbered cards + 1 card back) generated for The Mind game:
+
+- **Source**: Procedurally generated using `scripts/generate-mind-cards.ts`
+- **License**: MIT (original procedural generation, no external assets used)
+- **Format**: SVG, 140x190px
+- **Generator**: Run `npx tsx scripts/generate-mind-cards.ts` to regenerate
+
+Files (in `cards/the-mind/`):
+- `mind-{1-100}.svg` — numbered cards (dark teal background, gold accents, white number)
+- `mind-back.svg` — card back with mystery theme (radiating lines, "?" symbol)

--- a/public/assets/cards/the-mind/mind-1.svg
+++ b/public/assets/cards/the-mind/mind-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">1</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">1</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">1</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-10.svg
+++ b/public/assets/cards/the-mind/mind-10.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">10</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">10</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">10</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-100.svg
+++ b/public/assets/cards/the-mind/mind-100.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">100</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">100</text>
+  <text x="70" y="109.66666666666667" font-family="Arial, sans-serif" font-size="44" font-weight="bold" text-anchor="middle" fill="#ffffff">100</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-11.svg
+++ b/public/assets/cards/the-mind/mind-11.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">11</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">11</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">11</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-12.svg
+++ b/public/assets/cards/the-mind/mind-12.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">12</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">12</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">12</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-13.svg
+++ b/public/assets/cards/the-mind/mind-13.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">13</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">13</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">13</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-14.svg
+++ b/public/assets/cards/the-mind/mind-14.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">14</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">14</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">14</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-15.svg
+++ b/public/assets/cards/the-mind/mind-15.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">15</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">15</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">15</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-16.svg
+++ b/public/assets/cards/the-mind/mind-16.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">16</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">16</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">16</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-17.svg
+++ b/public/assets/cards/the-mind/mind-17.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">17</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">17</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">17</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-18.svg
+++ b/public/assets/cards/the-mind/mind-18.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">18</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">18</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">18</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-19.svg
+++ b/public/assets/cards/the-mind/mind-19.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">19</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">19</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">19</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-2.svg
+++ b/public/assets/cards/the-mind/mind-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">2</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">2</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">2</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-20.svg
+++ b/public/assets/cards/the-mind/mind-20.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">20</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">20</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">20</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-21.svg
+++ b/public/assets/cards/the-mind/mind-21.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">21</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">21</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">21</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-22.svg
+++ b/public/assets/cards/the-mind/mind-22.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">22</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">22</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">22</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-23.svg
+++ b/public/assets/cards/the-mind/mind-23.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">23</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">23</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">23</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-24.svg
+++ b/public/assets/cards/the-mind/mind-24.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">24</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">24</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">24</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-25.svg
+++ b/public/assets/cards/the-mind/mind-25.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">25</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">25</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">25</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-26.svg
+++ b/public/assets/cards/the-mind/mind-26.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">26</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">26</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">26</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-27.svg
+++ b/public/assets/cards/the-mind/mind-27.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">27</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">27</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">27</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-28.svg
+++ b/public/assets/cards/the-mind/mind-28.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">28</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">28</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">28</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-29.svg
+++ b/public/assets/cards/the-mind/mind-29.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">29</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">29</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">29</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-3.svg
+++ b/public/assets/cards/the-mind/mind-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">3</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">3</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">3</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-30.svg
+++ b/public/assets/cards/the-mind/mind-30.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">30</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">30</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">30</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-31.svg
+++ b/public/assets/cards/the-mind/mind-31.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">31</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">31</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">31</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-32.svg
+++ b/public/assets/cards/the-mind/mind-32.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">32</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">32</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">32</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-33.svg
+++ b/public/assets/cards/the-mind/mind-33.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">33</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">33</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">33</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-34.svg
+++ b/public/assets/cards/the-mind/mind-34.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">34</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">34</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">34</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-35.svg
+++ b/public/assets/cards/the-mind/mind-35.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">35</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">35</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">35</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-36.svg
+++ b/public/assets/cards/the-mind/mind-36.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">36</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">36</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">36</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-37.svg
+++ b/public/assets/cards/the-mind/mind-37.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">37</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">37</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">37</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-38.svg
+++ b/public/assets/cards/the-mind/mind-38.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">38</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">38</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">38</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-39.svg
+++ b/public/assets/cards/the-mind/mind-39.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">39</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">39</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">39</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-4.svg
+++ b/public/assets/cards/the-mind/mind-4.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">4</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">4</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">4</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-40.svg
+++ b/public/assets/cards/the-mind/mind-40.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">40</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">40</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">40</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-41.svg
+++ b/public/assets/cards/the-mind/mind-41.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">41</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">41</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">41</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-42.svg
+++ b/public/assets/cards/the-mind/mind-42.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">42</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">42</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">42</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-43.svg
+++ b/public/assets/cards/the-mind/mind-43.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">43</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">43</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">43</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-44.svg
+++ b/public/assets/cards/the-mind/mind-44.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">44</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">44</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">44</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-45.svg
+++ b/public/assets/cards/the-mind/mind-45.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">45</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">45</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">45</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-46.svg
+++ b/public/assets/cards/the-mind/mind-46.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">46</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">46</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">46</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-47.svg
+++ b/public/assets/cards/the-mind/mind-47.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">47</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">47</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">47</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-48.svg
+++ b/public/assets/cards/the-mind/mind-48.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">48</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">48</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">48</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-49.svg
+++ b/public/assets/cards/the-mind/mind-49.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">49</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">49</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">49</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-5.svg
+++ b/public/assets/cards/the-mind/mind-5.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">5</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">5</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">5</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-50.svg
+++ b/public/assets/cards/the-mind/mind-50.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">50</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">50</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">50</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-51.svg
+++ b/public/assets/cards/the-mind/mind-51.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">51</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">51</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">51</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-52.svg
+++ b/public/assets/cards/the-mind/mind-52.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">52</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">52</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">52</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-53.svg
+++ b/public/assets/cards/the-mind/mind-53.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">53</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">53</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">53</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-54.svg
+++ b/public/assets/cards/the-mind/mind-54.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">54</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">54</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">54</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-55.svg
+++ b/public/assets/cards/the-mind/mind-55.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">55</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">55</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">55</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-56.svg
+++ b/public/assets/cards/the-mind/mind-56.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">56</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">56</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">56</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-57.svg
+++ b/public/assets/cards/the-mind/mind-57.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">57</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">57</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">57</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-58.svg
+++ b/public/assets/cards/the-mind/mind-58.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">58</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">58</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">58</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-59.svg
+++ b/public/assets/cards/the-mind/mind-59.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">59</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">59</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">59</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-6.svg
+++ b/public/assets/cards/the-mind/mind-6.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">6</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">6</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">6</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-60.svg
+++ b/public/assets/cards/the-mind/mind-60.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">60</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">60</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">60</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-61.svg
+++ b/public/assets/cards/the-mind/mind-61.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">61</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">61</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">61</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-62.svg
+++ b/public/assets/cards/the-mind/mind-62.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">62</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">62</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">62</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-63.svg
+++ b/public/assets/cards/the-mind/mind-63.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">63</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">63</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">63</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-64.svg
+++ b/public/assets/cards/the-mind/mind-64.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">64</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">64</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">64</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-65.svg
+++ b/public/assets/cards/the-mind/mind-65.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">65</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">65</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">65</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-66.svg
+++ b/public/assets/cards/the-mind/mind-66.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">66</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">66</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">66</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-67.svg
+++ b/public/assets/cards/the-mind/mind-67.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">67</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">67</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">67</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-68.svg
+++ b/public/assets/cards/the-mind/mind-68.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">68</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">68</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">68</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-69.svg
+++ b/public/assets/cards/the-mind/mind-69.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">69</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">69</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">69</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-7.svg
+++ b/public/assets/cards/the-mind/mind-7.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">7</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">7</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">7</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-70.svg
+++ b/public/assets/cards/the-mind/mind-70.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">70</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">70</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">70</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-71.svg
+++ b/public/assets/cards/the-mind/mind-71.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">71</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">71</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">71</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-72.svg
+++ b/public/assets/cards/the-mind/mind-72.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">72</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">72</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">72</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-73.svg
+++ b/public/assets/cards/the-mind/mind-73.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">73</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">73</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">73</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-74.svg
+++ b/public/assets/cards/the-mind/mind-74.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">74</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">74</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">74</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-75.svg
+++ b/public/assets/cards/the-mind/mind-75.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">75</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">75</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">75</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-76.svg
+++ b/public/assets/cards/the-mind/mind-76.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">76</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">76</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">76</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-77.svg
+++ b/public/assets/cards/the-mind/mind-77.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">77</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">77</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">77</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-78.svg
+++ b/public/assets/cards/the-mind/mind-78.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">78</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">78</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">78</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-79.svg
+++ b/public/assets/cards/the-mind/mind-79.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">79</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">79</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">79</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-8.svg
+++ b/public/assets/cards/the-mind/mind-8.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">8</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">8</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">8</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-80.svg
+++ b/public/assets/cards/the-mind/mind-80.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">80</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">80</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">80</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-81.svg
+++ b/public/assets/cards/the-mind/mind-81.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">81</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">81</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">81</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-82.svg
+++ b/public/assets/cards/the-mind/mind-82.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">82</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">82</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">82</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-83.svg
+++ b/public/assets/cards/the-mind/mind-83.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">83</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">83</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">83</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-84.svg
+++ b/public/assets/cards/the-mind/mind-84.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">84</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">84</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">84</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-85.svg
+++ b/public/assets/cards/the-mind/mind-85.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">85</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">85</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">85</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-86.svg
+++ b/public/assets/cards/the-mind/mind-86.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">86</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">86</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">86</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-87.svg
+++ b/public/assets/cards/the-mind/mind-87.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">87</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">87</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">87</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-88.svg
+++ b/public/assets/cards/the-mind/mind-88.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">88</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">88</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">88</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-89.svg
+++ b/public/assets/cards/the-mind/mind-89.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">89</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">89</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">89</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-9.svg
+++ b/public/assets/cards/the-mind/mind-9.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">9</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">9</text>
+  <text x="70" y="113.66666666666667" font-family="Arial, sans-serif" font-size="56" font-weight="bold" text-anchor="middle" fill="#ffffff">9</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-90.svg
+++ b/public/assets/cards/the-mind/mind-90.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">90</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">90</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">90</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-91.svg
+++ b/public/assets/cards/the-mind/mind-91.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">91</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">91</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">91</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-92.svg
+++ b/public/assets/cards/the-mind/mind-92.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">92</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">92</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">92</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-93.svg
+++ b/public/assets/cards/the-mind/mind-93.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">93</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">93</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">93</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-94.svg
+++ b/public/assets/cards/the-mind/mind-94.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">94</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">94</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">94</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-95.svg
+++ b/public/assets/cards/the-mind/mind-95.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">95</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">95</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">95</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-96.svg
+++ b/public/assets/cards/the-mind/mind-96.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">96</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">96</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">96</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-97.svg
+++ b/public/assets/cards/the-mind/mind-97.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">97</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">97</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">97</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-98.svg
+++ b/public/assets/cards/the-mind/mind-98.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">98</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">98</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">98</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-99.svg
+++ b/public/assets/cards/the-mind/mind-99.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="8" y="8" width="124" height="174" rx="6" ry="6" fill="none" stroke="#d4a843" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="70" cy="95" r="42" fill="none" stroke="#d4a843" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="70" cy="95" r="34" fill="none" stroke="#d4a843" stroke-width="0.4" opacity="0.15"/>
+  <text x="16" y="30" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843">99</text>
+  <text x="124" y="174" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#d4a843" transform="rotate(180,124,166)">99</text>
+  <text x="70" y="112.33333333333333" font-family="Arial, sans-serif" font-size="52" font-weight="bold" text-anchor="middle" fill="#ffffff">99</text>
+</svg>

--- a/public/assets/cards/the-mind/mind-back.svg
+++ b/public/assets/cards/the-mind/mind-back.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="190" viewBox="0 0 140 190">
+  <rect width="140" height="190" rx="10" ry="10" fill="#1a2a3a"/>
+  <rect x="1" y="1" width="138" height="188" rx="9" ry="9" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <rect x="6" y="6" width="128" height="178" rx="7" ry="7" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+  <line x1="90.0" y1="95.0" x2="125.0" y2="95.0" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="87.3" y1="105.0" x2="117.6" y2="122.5" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="80.0" y1="112.3" x2="97.5" y2="142.6" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="70.0" y1="115.0" x2="70.0" y2="150.0" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="60.0" y1="112.3" x2="42.5" y2="142.6" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="52.7" y1="105.0" x2="22.4" y2="122.5" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="50.0" y1="95.0" x2="15.0" y2="95.0" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="52.7" y1="85.0" x2="22.4" y2="67.5" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="60.0" y1="77.7" x2="42.5" y2="47.4" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="70.0" y1="75.0" x2="70.0" y2="40.0" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="80.0" y1="77.7" x2="97.5" y2="47.4" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="87.3" y1="85.0" x2="117.6" y2="67.5" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <circle cx="70" cy="95" r="38" fill="none" stroke="#d4a843" stroke-width="2" opacity="0.4"/>
+  <circle cx="70" cy="95" r="28" fill="#d4a843" opacity="0.15"/>
+  <text x="70" y="109" font-family="serif" font-size="40" font-weight="bold" text-anchor="middle" fill="#d4a843">?</text>
+</svg>

--- a/scripts/generate-mind-cards.ts
+++ b/scripts/generate-mind-cards.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env npx tsx
+/**
+ * generate-mind-cards.ts
+ *
+ * Generates 101 SVG card images for The Mind:
+ *   - 100 numbered cards (values 1-100)
+ *   - 1 card back
+ *
+ * Output: public/assets/cards/the-mind/{assetKey}.svg
+ * Card size: 140x190px
+ *
+ * Usage:
+ *   npx tsx scripts/generate-mind-cards.ts
+ */
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ── Constants ──────────────────────────────────────────────
+
+const CARD_W = 140;
+const CARD_H = 190;
+const CORNER_R = 10;
+const OUT_DIR = join(__dirname, '..', 'public', 'assets', 'cards', 'the-mind');
+
+/** Card face background — deep teal/blue-green. */
+const BG_COLOR = '#1a2a3a';
+
+/** Accent color — warm gold for borders and decoration. */
+const ACCENT_COLOR = '#d4a843';
+
+/** Number text color — bright white for legibility. */
+const TEXT_COLOR = '#ffffff';
+
+/** Card back background. */
+const BACK_BG = '#1a2a3a';
+
+/** Card back accent. */
+const BACK_ACCENT = '#d4a843';
+
+// ── SVG template helpers ───────────────────────────────────
+
+function svgHeader(): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${CARD_W}" height="${CARD_H}" viewBox="0 0 ${CARD_W} ${CARD_H}">`;
+}
+
+function cardBackground(fill: string): string {
+  return `  <rect width="${CARD_W}" height="${CARD_H}" rx="${CORNER_R}" ry="${CORNER_R}" fill="${fill}"/>`;
+}
+
+function cardBorder(stroke: string): string {
+  return `  <rect x="1" y="1" width="${CARD_W - 2}" height="${CARD_H - 2}" rx="${CORNER_R - 1}" ry="${CORNER_R - 1}" fill="none" stroke="${stroke}" stroke-width="1.5"/>`;
+}
+
+function innerFrame(stroke: string): string {
+  return `  <rect x="8" y="8" width="${CARD_W - 16}" height="${CARD_H - 16}" rx="6" ry="6" fill="none" stroke="${stroke}" stroke-width="0.8" opacity="0.4"/>`;
+}
+
+// ── Card generators ────────────────────────────────────────
+
+/**
+ * Generate a numbered Mind card (1-100).
+ *
+ * Layout:
+ * - Dark background with gold border and inner frame
+ * - Large centered number for quick readability
+ * - Small corner numbers (top-left, bottom-right rotated)
+ * - Subtle concentric circle decoration behind the number
+ */
+function generateNumberedCard(value: number): string {
+  // Scale font size: 1-digit (56px), 2-digit (52px), 3-digit (44px)
+  const digits = String(value).length;
+  const mainFontSize = digits === 1 ? 56 : digits === 2 ? 52 : 44;
+  const cornerFontSize = 18;
+
+  // Subtle radial decoration behind the number
+  const decoration = `  <circle cx="${CARD_W / 2}" cy="${CARD_H / 2}" r="42" fill="none" stroke="${ACCENT_COLOR}" stroke-width="0.6" opacity="0.25"/>
+  <circle cx="${CARD_W / 2}" cy="${CARD_H / 2}" r="34" fill="none" stroke="${ACCENT_COLOR}" stroke-width="0.4" opacity="0.15"/>`;
+
+  // Corner numbers
+  const corners = `  <text x="16" y="30" font-family="Arial, sans-serif" font-size="${cornerFontSize}" font-weight="bold" text-anchor="middle" fill="${ACCENT_COLOR}">${value}</text>
+  <text x="${CARD_W - 16}" y="${CARD_H - 16}" font-family="Arial, sans-serif" font-size="${cornerFontSize}" font-weight="bold" text-anchor="middle" fill="${ACCENT_COLOR}" transform="rotate(180,${CARD_W - 16},${CARD_H - 24})">${value}</text>`;
+
+  // Main centered number
+  const mainNumber = `  <text x="${CARD_W / 2}" y="${CARD_H / 2 + mainFontSize / 3}" font-family="Arial, sans-serif" font-size="${mainFontSize}" font-weight="bold" text-anchor="middle" fill="${TEXT_COLOR}">${value}</text>`;
+
+  return `${svgHeader()}
+${cardBackground(BG_COLOR)}
+${cardBorder(ACCENT_COLOR)}
+${innerFrame(ACCENT_COLOR)}
+${decoration}
+${corners}
+${mainNumber}
+</svg>`;
+}
+
+/**
+ * Generate the Mind card back.
+ *
+ * Design: Dark background with gold accents, concentric circles,
+ * and a central "?" symbol representing the unknown.
+ */
+function generateCardBack(): string {
+  // Radiating lines pattern
+  const lines: string[] = [];
+  for (let angle = 0; angle < 360; angle += 30) {
+    const rad = (angle * Math.PI) / 180;
+    const cx = CARD_W / 2;
+    const cy = CARD_H / 2;
+    const x1 = cx + Math.cos(rad) * 20;
+    const y1 = cy + Math.sin(rad) * 20;
+    const x2 = cx + Math.cos(rad) * 55;
+    const y2 = cy + Math.sin(rad) * 55;
+    lines.push(
+      `  <line x1="${x1.toFixed(1)}" y1="${y1.toFixed(1)}" x2="${x2.toFixed(1)}" y2="${y2.toFixed(1)}" stroke="${BACK_ACCENT}" stroke-width="1" opacity="0.15"/>`,
+    );
+  }
+
+  return `${svgHeader()}
+${cardBackground(BACK_BG)}
+${cardBorder(BACK_ACCENT)}
+  <rect x="6" y="6" width="${CARD_W - 12}" height="${CARD_H - 12}" rx="7" ry="7" fill="none" stroke="${BACK_ACCENT}" stroke-width="1.5"/>
+${lines.join('\n')}
+  <circle cx="${CARD_W / 2}" cy="${CARD_H / 2}" r="38" fill="none" stroke="${BACK_ACCENT}" stroke-width="2" opacity="0.4"/>
+  <circle cx="${CARD_W / 2}" cy="${CARD_H / 2}" r="28" fill="${BACK_ACCENT}" opacity="0.15"/>
+  <text x="${CARD_W / 2}" y="${CARD_H / 2 + 14}" font-family="serif" font-size="40" font-weight="bold" text-anchor="middle" fill="${BACK_ACCENT}">?</text>
+</svg>`;
+}
+
+// ── Main ───────────────────────────────────────────────────
+
+function main(): void {
+  // Ensure output directory exists
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  let count = 0;
+
+  // Generate numbered cards (1-100)
+  for (let value = 1; value <= 100; value++) {
+    const key = `mind-${value}`;
+    const svg = generateNumberedCard(value);
+    writeFileSync(join(OUT_DIR, `${key}.svg`), svg);
+    count++;
+  }
+
+  // Generate card back (1 card)
+  const backSvg = generateCardBack();
+  writeFileSync(join(OUT_DIR, 'mind-back.svg'), backSvg);
+  count++;
+
+  console.log(`Generated ${count} SVG card images in ${OUT_DIR}`);
+}
+
+main();

--- a/tests/the-mind/mind-card-renderer.test.ts
+++ b/tests/the-mind/mind-card-renderer.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { MindCard } from '../../example-games/the-mind/MindCard';
+import {
+  CARD_BACK_KEY,
+  MIN_VALUE,
+  MAX_VALUE,
+} from '../../example-games/the-mind/MindCard';
+import {
+  getMindCardTexture,
+  mindCardTextureKey,
+  MIND_CARD_W,
+  MIND_CARD_H,
+} from '../../example-games/the-mind/MindCardRenderer';
+
+// ── Constants ────────────────────────────────────────────────
+
+const ASSETS_DIR = join(__dirname, '..', '..', 'public', 'assets', 'cards', 'the-mind');
+
+// ── Helper ───────────────────────────────────────────────────
+
+function makeMindCard(value: number, faceUp: boolean): MindCard {
+  return { value, faceUp };
+}
+
+// ── getMindCardTexture ───────────────────────────────────────
+
+describe('getMindCardTexture', () => {
+  it('should return card back key for a face-down card', () => {
+    const card = makeMindCard(42, false);
+    expect(getMindCardTexture(card)).toBe(CARD_BACK_KEY);
+  });
+
+  it('should return the correct texture key for a face-up card', () => {
+    const card = makeMindCard(42, true);
+    expect(getMindCardTexture(card)).toBe('mind-42');
+  });
+
+  it('should return correct key for value 1', () => {
+    const card = makeMindCard(1, true);
+    expect(getMindCardTexture(card)).toBe('mind-1');
+  });
+
+  it('should return correct key for value 100', () => {
+    const card = makeMindCard(100, true);
+    expect(getMindCardTexture(card)).toBe('mind-100');
+  });
+
+  it('should return card back when faceUp is toggled to false', () => {
+    const card = makeMindCard(50, true);
+    expect(getMindCardTexture(card)).toBe('mind-50');
+    card.faceUp = false;
+    expect(getMindCardTexture(card)).toBe(CARD_BACK_KEY);
+  });
+
+  it('should throw for value 0', () => {
+    const card = makeMindCard(0, true);
+    expect(() => getMindCardTexture(card)).toThrow('Invalid Mind card value: 0');
+  });
+
+  it('should throw for value 101', () => {
+    const card = makeMindCard(101, true);
+    expect(() => getMindCardTexture(card)).toThrow('Invalid Mind card value: 101');
+  });
+
+  it('should throw for negative values', () => {
+    const card = makeMindCard(-5, true);
+    expect(() => getMindCardTexture(card)).toThrow('Invalid Mind card value: -5');
+  });
+
+  it('should throw for non-integer values', () => {
+    const card = makeMindCard(3.5, true);
+    expect(() => getMindCardTexture(card)).toThrow('Invalid Mind card value: 3.5');
+  });
+
+  it('should NOT throw for face-down cards with invalid values (back key returned before validation)', () => {
+    const card = makeMindCard(0, false);
+    expect(getMindCardTexture(card)).toBe(CARD_BACK_KEY);
+  });
+});
+
+// ── mindCardTextureKey ───────────────────────────────────────
+
+describe('mindCardTextureKey', () => {
+  it('should return mind-1 for value 1', () => {
+    expect(mindCardTextureKey(1)).toBe('mind-1');
+  });
+
+  it('should return mind-50 for value 50', () => {
+    expect(mindCardTextureKey(50)).toBe('mind-50');
+  });
+
+  it('should return mind-100 for value 100', () => {
+    expect(mindCardTextureKey(100)).toBe('mind-100');
+  });
+
+  it('should throw for value 0', () => {
+    expect(() => mindCardTextureKey(0)).toThrow('Invalid Mind card value');
+  });
+
+  it('should throw for value 101', () => {
+    expect(() => mindCardTextureKey(101)).toThrow('Invalid Mind card value');
+  });
+
+  it('should throw for NaN', () => {
+    expect(() => mindCardTextureKey(NaN)).toThrow('Invalid Mind card value');
+  });
+
+  it('should throw for Infinity', () => {
+    expect(() => mindCardTextureKey(Infinity)).toThrow('Invalid Mind card value');
+  });
+});
+
+// ── Constants exports ────────────────────────────────────────
+
+describe('MindCardRenderer constants', () => {
+  it('should export MIND_CARD_W as 48', () => {
+    expect(MIND_CARD_W).toBe(48);
+  });
+
+  it('should export MIND_CARD_H as 65', () => {
+    expect(MIND_CARD_H).toBe(65);
+  });
+});
+
+// ── SVG asset file existence ─────────────────────────────────
+
+describe('generated SVG assets', () => {
+  it('should have generated 101 SVG files in the-mind directory', () => {
+    expect(existsSync(ASSETS_DIR)).toBe(true);
+  });
+
+  it('should have a card back SVG (mind-back.svg)', () => {
+    const filePath = join(ASSETS_DIR, 'mind-back.svg');
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it.each([1, 2, 10, 42, 50, 99, 100])(
+    'should have numbered card SVG for value %d',
+    (value) => {
+      const filePath = join(ASSETS_DIR, `mind-${value}.svg`);
+      expect(existsSync(filePath)).toBe(true);
+    },
+  );
+
+  it('should have all 100 numbered card SVGs (1-100)', () => {
+    for (let v = MIN_VALUE; v <= MAX_VALUE; v++) {
+      const filePath = join(ASSETS_DIR, `mind-${v}.svg`);
+      expect(existsSync(filePath)).toBe(true);
+    }
+  });
+});
+
+// ── SVG content validation ───────────────────────────────────
+
+describe('SVG content structure', () => {
+  it('should have correct dimensions (140x190) in numbered card SVGs', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-42.svg'), 'utf8');
+    expect(svg).toContain('width="140"');
+    expect(svg).toContain('height="190"');
+    expect(svg).toContain('viewBox="0 0 140 190"');
+  });
+
+  it('should have correct dimensions (140x190) in card back SVG', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-back.svg'), 'utf8');
+    expect(svg).toContain('width="140"');
+    expect(svg).toContain('height="190"');
+  });
+
+  it('should contain the card value as text in a numbered card SVG', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-42.svg'), 'utf8');
+    expect(svg).toContain('>42<');
+  });
+
+  it('should contain the value 100 in the 3-digit card SVG', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-100.svg'), 'utf8');
+    expect(svg).toContain('>100<');
+  });
+
+  it('should contain the value 1 in the single-digit card SVG', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-1.svg'), 'utf8');
+    expect(svg).toContain('>1<');
+  });
+
+  it('should contain a "?" in the card back SVG', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-back.svg'), 'utf8');
+    expect(svg).toContain('>?<');
+  });
+
+  it('should be valid SVG (starts with <svg and ends with </svg>)', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-42.svg'), 'utf8');
+    expect(svg.trim()).toMatch(/^<svg[\s\S]*<\/svg>$/);
+  });
+
+  it('should use rounded corners (rx attribute)', () => {
+    const svg = readFileSync(join(ASSETS_DIR, 'mind-42.svg'), 'utf8');
+    expect(svg).toContain('rx="10"');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **SVG Card Template & Runtime Rendering** (Feature 2) for The Mind card game (epic CG-0MLSDXNMM1R2IMT9).

- Adds `scripts/generate-mind-cards.ts` procedural SVG generator creating 101 card images (100 numbered + 1 card back) following the Lost Cities generator pattern
- Generates 101 SVGs at 140x190px in `public/assets/cards/the-mind/` with dark teal background, gold accents, and large white numbers for quick readability
- Adds `MindCardRenderer.ts` with `getMindCardTexture()`, `mindCardTextureKey()`, and `preloadMindCardAssets()` for Phaser scene integration
- Adds 37 unit tests covering texture key mapping, validation (throws for value 0, 101, NaN, decimals, etc.), constants, SVG file existence, and SVG content structure
- Updates `CREDITS.md` with The Mind card asset attribution

## Design Decisions

- **Procedurally generated individual SVGs** rather than a single template with runtime compositing, following the Lost Cities pattern and aligning with the existing `cardAssetKey()` conventions in MindCard.ts
- **Custom card back (`mind-back`)** with mystery theme (radiating lines, "?" symbol) rather than reusing the standard `card_back.svg` which has a playing card aesthetic
- **Font sizes scale with digit count**: 1-digit (56px), 2-digit (52px), 3-digit (44px) for optimal readability across all 100 values

## Files Changed

- `scripts/generate-mind-cards.ts` — SVG card generator (155 lines)
- `example-games/the-mind/MindCardRenderer.ts` — Texture helpers and preload function (96 lines)
- `tests/the-mind/mind-card-renderer.test.ts` — 37 unit tests (176 lines)
- `public/assets/CREDITS.md` — Added The Mind card asset attribution
- `public/assets/cards/the-mind/*.svg` — 101 generated SVG card images

## Acceptance Criteria

All 6 acceptance criteria verified:
1. SVG card assets exist (101 files in `public/assets/cards/the-mind/`)
2. Utility functions generate texture keys for any MindCard value (1-100)
3. Card back uses themed `mind-back` key
4. Textures loaded into Phaser texture manager via `preloadMindCardAssets()`
5. Value 0 or 101 throws an error
6. Asset attribution added to CREDITS.md

## Related Work Items

- **Epic:** CG-0MLSDXNMM1R2IMT9 (The Mind)
- **This feature:** CG-0MLZSJHGL1A02AQD (SVG Card Template & Runtime Rendering)
- **Dependency:** CG-0MLZSJ6XI1LA5T4R (MindCard Type & Deck Factory) — completed
- **Unblocked by this PR:** CG-0MLZSL72J0GYE6WM (Core Gameplay Phaser Scene)