### PR TITLE
CG-0MLZSLMEL0WJDTPZ: Auto-Play Spectator Mode for The Mind

### DIFF
--- a/example-games/the-mind/headlessGame.ts
+++ b/example-games/the-mind/headlessGame.ts
@@ -1,0 +1,283 @@
+/**
+ * headlessGame.ts
+ *
+ * Headless (no Phaser) game runner for The Mind.
+ *
+ * Simulates a complete AI-vs-AI game by computing timing delays for
+ * both players, then resolving plays in chronological order. Produces
+ * a valid MindTranscript identical in structure to interactive games.
+ *
+ * Usage:
+ *   import { runGame } from './headlessGame';
+ *   const result = runGame({ seed: 42 });
+ *   console.log(result.transcript.results);
+ *
+ * @module
+ */
+
+import { createSeededRng } from '../../src/core-engine/SeededRng';
+import type { PlayerId, TheMindSession } from './TheMindGameState';
+import {
+  setupTheMindGame,
+  playCard,
+  isGameOver,
+  getPileTopValue,
+} from './TheMindGameState';
+import { MindAiPlayer } from './AiStrategy';
+import type { MindAiTimingConfig } from './AiStrategy';
+import { MindTranscriptRecorder } from './GameTranscript';
+import type { MindTranscript, MindInitialState } from './GameTranscript';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Configuration for a headless game run. */
+export interface HeadlessGameConfig {
+  /** Seed for the game RNG (deck shuffling). Defaults to 42. */
+  seed?: number;
+  /**
+   * Seed for Player 0's AI timing RNG. Defaults to seed + 1.
+   * Using a different seed from Player 1 ensures independent timing.
+   */
+  player0AiSeed?: number;
+  /**
+   * Seed for Player 1's AI timing RNG. Defaults to seed + 2.
+   */
+  player1AiSeed?: number;
+  /** Optional timing config override for both AI players. */
+  timingConfig?: Partial<MindAiTimingConfig>;
+  /** Player names. Defaults to ['AI-0', 'AI-1']. */
+  playerNames?: [string, string];
+}
+
+/** Result of a headless game run. */
+export interface HeadlessGameResult {
+  /** The finalized transcript. */
+  readonly transcript: MindTranscript;
+  /** Total number of card plays across all levels. */
+  readonly totalPlays: number;
+  /** Total number of penalties incurred. */
+  readonly totalPenalties: number;
+  /** Final game outcome. */
+  readonly outcome: 'win' | 'loss';
+  /** Final level reached. */
+  readonly finalLevel: number;
+  /** Lives remaining at game end. */
+  readonly finalLives: number;
+}
+
+/** A pending card play in the simulation queue. */
+interface PendingPlay {
+  /** Which player will play this card. */
+  readonly playerId: PlayerId;
+  /** The card value to play. */
+  readonly cardValue: number;
+  /** Absolute simulation time (ms) when this play fires. */
+  readonly fireTime: number;
+}
+
+// ---------------------------------------------------------------------------
+// Headless runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a complete headless AI-vs-AI game of The Mind.
+ *
+ * Both players use the linear timing strategy with independent seeded
+ * RNGs. The simulation resolves plays in chronological order by their
+ * computed fire times, handling penalties and level transitions.
+ *
+ * @param config - Optional configuration for seeds, timing, and names.
+ * @returns A HeadlessGameResult with the finalized transcript and stats.
+ */
+export function runGame(config?: HeadlessGameConfig): HeadlessGameResult {
+  const seed = config?.seed ?? 42;
+  const p0AiSeed = config?.player0AiSeed ?? seed + 1;
+  const p1AiSeed = config?.player1AiSeed ?? seed + 2;
+  const names = config?.playerNames ?? ['AI-0', 'AI-1'];
+
+  // Create game session with seeded RNG
+  const gameRng = createSeededRng(seed);
+  const session = setupTheMindGame({
+    playerNames: names,
+    isAI: [true, true],
+    rng: gameRng,
+  });
+
+  // Create AI players with independent RNGs
+  const aiPlayers: [MindAiPlayer, MindAiPlayer] = [
+    new MindAiPlayer(undefined, createSeededRng(p0AiSeed), config?.timingConfig),
+    new MindAiPlayer(undefined, createSeededRng(p1AiSeed), config?.timingConfig),
+  ];
+
+  // Create transcript recorder
+  const initialState: MindInitialState = {
+    playerNames: names,
+    isAI: [true, true],
+    startingLives: session.lives,
+    startingLevel: session.currentLevel,
+    hands: [
+      session.players[0].hand.map((c) => c.value),
+      session.players[1].hand.map((c) => c.value),
+    ],
+  };
+  const recorder = new MindTranscriptRecorder(initialState);
+
+  // Simulation state
+  let totalPlays = 0;
+  let totalPenalties = 0;
+  let levelStartTime = 0;
+
+  // Commit initial level delays
+  commitLevelDelays(session, aiPlayers, levelStartTime);
+
+  // Main simulation loop
+  while (!isGameOver(session)) {
+    // Build queue of pending plays from both players
+    const queue = buildPlayQueue(aiPlayers, levelStartTime);
+
+    if (queue.length === 0) {
+      // No cards left but game not over — shouldn't happen, but guard
+      break;
+    }
+
+    // Pick the earliest play
+    const next = queue[0];
+    const timestamp = next.fireTime - levelStartTime;
+
+    // Execute the play
+    const result = playCard(session, next.playerId, next.cardValue);
+
+    if (!result.success) {
+      // Card was already removed (e.g., by penalty). Remove from AI and retry.
+      aiPlayers[next.playerId].removeCard(next.cardValue);
+      continue;
+    }
+
+    totalPlays++;
+
+    // Record card play
+    recorder.recordCardPlay(
+      timestamp,
+      next.playerId,
+      next.cardValue,
+      getPileTopValue(session),
+      session.pile.size(),
+    );
+
+    // Remove from both AI players (the played card, and any penalty cards)
+    aiPlayers[next.playerId].removeCard(next.cardValue);
+
+    if (result.lifeLost) {
+      totalPenalties++;
+
+      recorder.recordPenalty(
+        timestamp,
+        session.lives,
+        result.penaltyCards.map((p) => ({
+          playerId: p.playerId,
+          cardValue: p.card.value,
+        })),
+      );
+
+      // Remove penalty cards from AI players
+      for (const pc of result.penaltyCards) {
+        aiPlayers[pc.playerId].removeCard(pc.card.value);
+      }
+    }
+
+    // Handle level completion (must be recorded before game-over check,
+    // since completing the final level triggers both levelComplete and
+    // game-over simultaneously)
+    if (result.levelComplete) {
+      // When the game is won, currentLevel stays at MAX_LEVEL (no dealLevel call).
+      // When a non-final level completes, dealLevel advances currentLevel.
+      const completedLevel = session.outcome === 'win'
+        ? session.currentLevel
+        : session.currentLevel - 1;
+
+      recorder.recordLevelComplete(
+        timestamp,
+        completedLevel,
+        result.bonusLifeAwarded,
+        session.lives,
+      );
+
+      if (isGameOver(session)) {
+        break;
+      }
+
+      // New level has been dealt by playCard — commit new delays
+      levelStartTime = next.fireTime;
+      commitLevelDelays(session, aiPlayers, levelStartTime);
+    }
+
+    // Check game over (loss from penalty with no level completion)
+    if (isGameOver(session)) {
+      break;
+    }
+  }
+
+  // Finalize transcript
+  const outcome = session.outcome as 'win' | 'loss';
+  const finalTimestamp = Date.now(); // arbitrary for headless
+  const transcript = recorder.finalize(
+    finalTimestamp,
+    outcome,
+    session.currentLevel,
+    session.lives,
+  );
+
+  return {
+    transcript,
+    totalPlays,
+    totalPenalties,
+    outcome,
+    finalLevel: session.currentLevel,
+    finalLives: session.lives,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Commit level delays for both AI players based on their current hands.
+ */
+function commitLevelDelays(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  _levelStartTime: number,
+): void {
+  aiPlayers[0].commitLevel(session.players[0].hand);
+  aiPlayers[1].commitLevel(session.players[1].hand);
+}
+
+/**
+ * Build a sorted queue of pending plays from both AI players.
+ * Returns plays sorted by fire time (earliest first).
+ */
+function buildPlayQueue(
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  levelStartTime: number,
+): PendingPlay[] {
+  const queue: PendingPlay[] = [];
+
+  for (let p = 0; p < 2; p++) {
+    const playerId = p as PlayerId;
+    const delays = aiPlayers[p].getCardDelays();
+    for (const d of delays) {
+      queue.push({
+        playerId,
+        cardValue: d.card.value,
+        fireTime: levelStartTime + Math.max(d.delay, 0),
+      });
+    }
+  }
+
+  // Sort by fire time, then by card value (lower card first on ties)
+  queue.sort((a, b) => a.fireTime - b.fireTime || a.cardValue - b.cardValue);
+  return queue;
+}

--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -99,6 +99,12 @@ export class TheMindScene extends Phaser.Scene {
   private aiTimer: Phaser.Time.TimerEvent | null = null;
   private aiLevelStartTime = 0;
 
+  // Auto-play spectator mode
+  private autoPlayEnabled = false;
+  private humanAiPlayer!: MindAiPlayer;
+  private humanAiTimer: Phaser.Time.TimerEvent | null = null;
+  private autoPlayButton!: Phaser.GameObjects.Text;
+
   // Event system
   private gameEvents!: GameEventEmitter;
   private eventBridge!: PhaserEventBridge;
@@ -143,7 +149,12 @@ export class TheMindScene extends Phaser.Scene {
     this.aiCardSprites = [];
     this.overlayObjects = [];
     this.aiTimer = null;
+    this.humanAiTimer = null;
     this.turnCounter = 0;
+
+    // Check URL parameter for auto-play
+    const urlParams = new URLSearchParams(window.location.search);
+    this.autoPlayEnabled = urlParams.get('autoplay') === 'true';
 
     // Event system
     this.gameEvents = new GameEventEmitter();
@@ -152,6 +163,7 @@ export class TheMindScene extends Phaser.Scene {
     // Setup game
     this.session = setupTheMindGame();
     this.aiPlayer = new MindAiPlayer();
+    this.humanAiPlayer = new MindAiPlayer();
 
     // Create transcript recorder
     this.recorder = this.createRecorder();
@@ -161,6 +173,7 @@ export class TheMindScene extends Phaser.Scene {
     this.createStatusDisplay();
     this.createPile();
     this.createInstruction();
+    this.createAutoPlayButton();
 
     // Initial render
     this.renderHumanHand();
@@ -248,6 +261,88 @@ export class TheMindScene extends Phaser.Scene {
       })
       .setOrigin(0.5)
       .setDepth(DEPTH_UI);
+  }
+
+  // ── Auto-play spectator mode ───────────────────────────
+
+  private createAutoPlayButton(): void {
+    const label = this.autoPlayEnabled ? '[ Auto-Play: ON ]' : '[ Auto-Play: OFF ]';
+    this.autoPlayButton = this.add
+      .text(20, GAME_H - 20, label, {
+        fontSize: '12px',
+        color: this.autoPlayEnabled ? '#88ff88' : '#888888',
+        fontFamily: FONT_FAMILY,
+      })
+      .setOrigin(0, 1)
+      .setDepth(DEPTH_UI)
+      .setInteractive({ useHandCursor: true });
+
+    this.autoPlayButton.on('pointerdown', () => this.toggleAutoPlay());
+    this.autoPlayButton.on('pointerover', () =>
+      this.autoPlayButton.setColor('#ffffff'),
+    );
+    this.autoPlayButton.on('pointerout', () =>
+      this.autoPlayButton.setColor(
+        this.autoPlayEnabled ? '#88ff88' : '#888888',
+      ),
+    );
+  }
+
+  private toggleAutoPlay(): void {
+    this.autoPlayEnabled = !this.autoPlayEnabled;
+
+    // Update button appearance
+    this.autoPlayButton.setText(
+      this.autoPlayEnabled ? '[ Auto-Play: ON ]' : '[ Auto-Play: OFF ]',
+    );
+    this.autoPlayButton.setColor(
+      this.autoPlayEnabled ? '#88ff88' : '#888888',
+    );
+
+    if (this.autoPlayEnabled) {
+      // Enabling: commit human AI delays for current hand and schedule
+      this.humanAiPlayer.commitLevel(this.session.players[0].hand);
+      this.instructionText.setText('Spectator mode — watching AI play');
+      if (this.phase === 'playing') {
+        this.scheduleHumanAiPlay();
+      }
+    } else {
+      // Disabling: cancel human AI timer
+      this.cancelHumanAiTimer();
+      if (this.phase === 'playing') {
+        this.instructionText.setText(
+          'Click a card to play it onto the pile',
+        );
+      }
+    }
+
+    this.gameEvents.emit('ui-interaction', {
+      elementId: 'auto-play-toggle',
+      action: this.autoPlayEnabled ? 'enabled' : 'disabled',
+    });
+  }
+
+  private scheduleHumanAiPlay(): void {
+    this.cancelHumanAiTimer();
+    if (!this.autoPlayEnabled) return;
+
+    const nextCard = this.humanAiPlayer.getNextCard();
+    if (!nextCard) return;
+
+    const elapsed = Date.now() - this.aiLevelStartTime;
+    const delay = Math.max(nextCard.delay - elapsed, 100);
+
+    this.humanAiTimer = this.time.delayedCall(delay, () => {
+      if (this.phase !== 'playing') return;
+      this.performPlay(0, nextCard.card.value);
+    });
+  }
+
+  private cancelHumanAiTimer(): void {
+    if (this.humanAiTimer) {
+      this.humanAiTimer.destroy();
+      this.humanAiTimer = null;
+    }
   }
 
   // ── Status refresh ─────────────────────────────────────
@@ -434,8 +529,17 @@ export class TheMindScene extends Phaser.Scene {
     // Commit AI delays for this level
     this.aiPlayer.commitLevel(this.session.players[1].hand);
 
+    // If auto-play is active, commit human AI delays too
+    if (this.autoPlayEnabled) {
+      this.humanAiPlayer.commitLevel(this.session.players[0].hand);
+    }
+
     this.setPhase('playing');
     this.scheduleAiPlay();
+
+    if (this.autoPlayEnabled) {
+      this.scheduleHumanAiPlay();
+    }
   }
 
   private setPhase(phase: GamePhase): void {
@@ -444,7 +548,9 @@ export class TheMindScene extends Phaser.Scene {
     switch (phase) {
       case 'playing':
         this.instructionText.setText(
-          'Click a card to play it onto the pile',
+          this.autoPlayEnabled
+            ? 'Spectator mode \u2014 watching AI play'
+            : 'Click a card to play it onto the pile',
         );
         break;
       case 'animating':
@@ -471,6 +577,7 @@ export class TheMindScene extends Phaser.Scene {
 
   private onHumanCardClick(card: MindCard): void {
     if (this.phase !== 'playing') return;
+    if (this.autoPlayEnabled) return; // Auto-play: ignore manual clicks
 
     this.performPlay(0, card.value);
   }
@@ -482,8 +589,8 @@ export class TheMindScene extends Phaser.Scene {
     const result = playCard(this.session, playerId, cardValue);
 
     if (!result.success) {
-      // Invalid play: shake feedback for human
-      if (playerId === 0) {
+      // Invalid play: shake feedback for human (only in manual mode)
+      if (playerId === 0 && !this.autoPlayEnabled) {
         this.showInvalidPlayFeedback(cardValue);
       }
       return;
@@ -500,12 +607,16 @@ export class TheMindScene extends Phaser.Scene {
       this.session.pile.size(),
     );
 
-    // Remove from AI committed delays if applicable
+    // Remove from both AI committed delays
     this.aiPlayer.removeCard(cardValue);
+    if (this.autoPlayEnabled) {
+      this.humanAiPlayer.removeCard(cardValue);
+    }
 
     // Handle penalty
     if (result.lifeLost) {
       this.cancelAiTimer();
+      this.cancelHumanAiTimer();
       this.setPhase('penalty');
 
       // Record penalty in transcript
@@ -518,9 +629,12 @@ export class TheMindScene extends Phaser.Scene {
         })),
       );
 
-      // Remove penalty cards from AI
+      // Remove penalty cards from both AI players
       for (const pc of result.penaltyCards) {
         this.aiPlayer.removeCard(pc.card.value);
+        if (this.autoPlayEnabled) {
+          this.humanAiPlayer.removeCard(pc.card.value);
+        }
       }
 
       // Flash lives display
@@ -545,6 +659,9 @@ export class TheMindScene extends Phaser.Scene {
         // Resume playing
         this.setPhase('playing');
         this.scheduleAiPlay();
+        if (this.autoPlayEnabled) {
+          this.scheduleHumanAiPlay();
+        }
       });
       return;
     }
@@ -563,6 +680,7 @@ export class TheMindScene extends Phaser.Scene {
       // Resume playing
       this.setPhase('playing');
       this.rescheduleAiIfNeeded();
+      this.rescheduleHumanAiIfNeeded();
     });
   }
 
@@ -677,6 +795,7 @@ export class TheMindScene extends Phaser.Scene {
 
   private handleLevelComplete(result: PlayResult, timestamp: number): void {
     this.cancelAiTimer();
+    this.cancelHumanAiTimer();
 
     // Record level completion in transcript
     this.recorder.recordLevelComplete(
@@ -743,6 +862,7 @@ export class TheMindScene extends Phaser.Scene {
 
   private handleGameOver(): void {
     this.cancelAiTimer();
+    this.cancelHumanAiTimer();
 
     const timestamp = Date.now() - this.levelStartTime;
     const outcome = this.session.outcome as 'win' | 'loss';
@@ -929,6 +1049,16 @@ export class TheMindScene extends Phaser.Scene {
     }
   }
 
+  private rescheduleHumanAiIfNeeded(): void {
+    if (
+      this.autoPlayEnabled &&
+      this.humanAiPlayer.hasCards() &&
+      this.phase === 'playing'
+    ) {
+      this.scheduleHumanAiPlay();
+    }
+  }
+
   private cancelAiTimer(): void {
     if (this.aiTimer) {
       this.aiTimer.destroy();
@@ -976,6 +1106,7 @@ export class TheMindScene extends Phaser.Scene {
 
   shutdown(): void {
     this.cancelAiTimer();
+    this.cancelHumanAiTimer();
     this.eventBridge?.destroy();
     this.gameEvents?.removeAllListeners();
 

--- a/tests/the-mind/auto-play.test.ts
+++ b/tests/the-mind/auto-play.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest';
+import {
+  runGame,
+  type HeadlessGameConfig,
+  type HeadlessGameResult,
+} from '../../example-games/the-mind/headlessGame';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Run a game with a known seed and return the result. */
+function runSeeded(seed: number, overrides?: Partial<HeadlessGameConfig>): HeadlessGameResult {
+  return runGame({ seed, ...overrides });
+}
+
+// ---------------------------------------------------------------------------
+// runGame — basic behaviour
+// ---------------------------------------------------------------------------
+
+describe('headless runGame', () => {
+  it('returns a result with outcome "win" or "loss"', () => {
+    const result = runSeeded(42);
+    expect(['win', 'loss']).toContain(result.outcome);
+  });
+
+  it('finalLevel is between 1 and 8', () => {
+    const result = runSeeded(42);
+    expect(result.finalLevel).toBeGreaterThanOrEqual(1);
+    expect(result.finalLevel).toBeLessThanOrEqual(8);
+  });
+
+  it('finalLives is >= 0', () => {
+    const result = runSeeded(42);
+    expect(result.finalLives).toBeGreaterThanOrEqual(0);
+  });
+
+  it('totalPlays is positive', () => {
+    const result = runSeeded(42);
+    expect(result.totalPlays).toBeGreaterThan(0);
+  });
+
+  it('totalPenalties is >= 0', () => {
+    const result = runSeeded(42);
+    expect(result.totalPenalties).toBeGreaterThanOrEqual(0);
+  });
+
+  it('outcome "loss" implies finalLives is 0', () => {
+    // Try several seeds to find a loss
+    for (let seed = 0; seed < 50; seed++) {
+      const result = runSeeded(seed);
+      if (result.outcome === 'loss') {
+        expect(result.finalLives).toBe(0);
+        return;
+      }
+    }
+    // If no loss found in 50 seeds, skip the assertion (unlikely)
+  });
+
+  it('outcome "win" implies finalLevel is 8', () => {
+    const zeroJitter = { baseDuration: 5000, jitterRange: 0 };
+    for (let seed = 0; seed < 100; seed++) {
+      const result = runGame({ seed, timingConfig: zeroJitter });
+      if (result.outcome === 'win') {
+        expect(result.finalLevel).toBe(8);
+        return;
+      }
+    }
+    // If no win found in 100 seeds with zero jitter, skip
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('headless runGame — determinism', () => {
+  it('same seed produces identical results', () => {
+    const a = runSeeded(123);
+    const b = runSeeded(123);
+
+    expect(a.outcome).toBe(b.outcome);
+    expect(a.totalPlays).toBe(b.totalPlays);
+    expect(a.totalPenalties).toBe(b.totalPenalties);
+    expect(a.finalLevel).toBe(b.finalLevel);
+    expect(a.finalLives).toBe(b.finalLives);
+  });
+
+  it('same seed produces identical transcript events (excluding timestamps)', () => {
+    const a = runSeeded(456);
+    const b = runSeeded(456);
+
+    // Compare event types and counts
+    const aEvents = a.transcript.events.map((e) => e.type);
+    const bEvents = b.transcript.events.map((e) => e.type);
+    expect(aEvents).toEqual(bEvents);
+
+    // Compare card-played events specifically
+    const aPlays = a.transcript.events.filter((e) => e.type === 'card-played');
+    const bPlays = b.transcript.events.filter((e) => e.type === 'card-played');
+    expect(aPlays.length).toBe(bPlays.length);
+
+    for (let i = 0; i < aPlays.length; i++) {
+      const ap = aPlays[i] as { playerId: number; cardValue: number };
+      const bp = bPlays[i] as { playerId: number; cardValue: number };
+      expect(ap.playerId).toBe(bp.playerId);
+      expect(ap.cardValue).toBe(bp.cardValue);
+    }
+  });
+
+  it('different seeds produce different results (at least sometimes)', () => {
+    const results: HeadlessGameResult[] = [];
+    for (let seed = 0; seed < 20; seed++) {
+      results.push(runSeeded(seed));
+    }
+
+    // At least two different outcomes or play counts across seeds
+    const uniquePlays = new Set(results.map((r) => r.totalPlays));
+    expect(uniquePlays.size).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+describe('headless runGame — configuration', () => {
+  it('uses default seed of 42 when no config provided', () => {
+    const noConfig = runGame();
+    const explicit42 = runGame({ seed: 42 });
+
+    expect(noConfig.outcome).toBe(explicit42.outcome);
+    expect(noConfig.totalPlays).toBe(explicit42.totalPlays);
+    expect(noConfig.finalLevel).toBe(explicit42.finalLevel);
+  });
+
+  it('respects custom player names', () => {
+    const result = runGame({
+      seed: 42,
+      playerNames: ['Alice', 'Bob'],
+    });
+
+    expect(result.transcript.initialState.playerNames).toEqual([
+      'Alice',
+      'Bob',
+    ]);
+  });
+
+  it('marks both players as AI', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.initialState.isAI).toEqual([true, true]);
+  });
+
+  it('respects custom AI seeds (different AI seeds = different play order)', () => {
+    const a = runGame({
+      seed: 42,
+      player0AiSeed: 100,
+      player1AiSeed: 200,
+    });
+    const b = runGame({
+      seed: 42,
+      player0AiSeed: 300,
+      player1AiSeed: 400,
+    });
+
+    // Same deck deal (same game seed) but different AI timing
+    // The total plays or penalties may differ
+    const aTotalEvents = a.transcript.events.length;
+    const bTotalEvents = b.transcript.events.length;
+
+    // They might happen to be the same, so just check both complete
+    expect(['win', 'loss']).toContain(a.outcome);
+    expect(['win', 'loss']).toContain(b.outcome);
+    // At minimum both should have events
+    expect(aTotalEvents).toBeGreaterThan(0);
+    expect(bTotalEvents).toBeGreaterThan(0);
+  });
+
+  it('respects custom timing config (zero jitter)', () => {
+    const a = runGame({
+      seed: 42,
+      timingConfig: { baseDuration: 5000, jitterRange: 0 },
+    });
+    const b = runGame({
+      seed: 42,
+      timingConfig: { baseDuration: 5000, jitterRange: 0 },
+    });
+
+    // With zero jitter, results must be perfectly deterministic
+    expect(a.outcome).toBe(b.outcome);
+    expect(a.totalPlays).toBe(b.totalPlays);
+    expect(a.totalPenalties).toBe(b.totalPenalties);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcript structure
+// ---------------------------------------------------------------------------
+
+describe('headless runGame — transcript', () => {
+  it('transcript version is 1', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.version).toBe(1);
+  });
+
+  it('transcript gameType is "the-mind"', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.gameType).toBe('the-mind');
+  });
+
+  it('transcript has startedAt and endedAt timestamps', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.startedAt).toBeTruthy();
+    expect(result.transcript.endedAt).toBeTruthy();
+  });
+
+  it('transcript results are populated', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.results).not.toBeNull();
+    expect(result.transcript.results!.outcome).toBe(result.outcome);
+    expect(result.transcript.results!.finalLevel).toBe(result.finalLevel);
+    expect(result.transcript.results!.finalLives).toBe(result.finalLives);
+  });
+
+  it('transcript has at least one card-played event', () => {
+    const result = runSeeded(42);
+    const plays = result.transcript.events.filter(
+      (e) => e.type === 'card-played',
+    );
+    expect(plays.length).toBeGreaterThan(0);
+  });
+
+  it('transcript ends with a game-over event', () => {
+    const result = runSeeded(42);
+    const lastEvent = result.transcript.events[result.transcript.events.length - 1];
+    expect(lastEvent.type).toBe('game-over');
+  });
+
+  it('transcript results totalCardsPlayed matches totalPlays', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.results!.totalCardsPlayed).toBe(result.totalPlays);
+  });
+
+  it('transcript results totalPenalties matches totalPenalties', () => {
+    const result = runSeeded(42);
+    expect(result.transcript.results!.totalPenalties).toBe(
+      result.totalPenalties,
+    );
+  });
+
+  it('card-played events have valid player IDs (0 or 1)', () => {
+    const result = runSeeded(42);
+    const plays = result.transcript.events.filter(
+      (e) => e.type === 'card-played',
+    );
+    for (const play of plays) {
+      const p = play as { playerId: number };
+      expect([0, 1]).toContain(p.playerId);
+    }
+  });
+
+  it('card-played events have card values between 1 and 100', () => {
+    const result = runSeeded(42);
+    const plays = result.transcript.events.filter(
+      (e) => e.type === 'card-played',
+    );
+    for (const play of plays) {
+      const p = play as { cardValue: number };
+      expect(p.cardValue).toBeGreaterThanOrEqual(1);
+      expect(p.cardValue).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('winning game has level-complete events for all 8 levels', () => {
+    // Use zero jitter for a realistic chance of finding a win
+    const zeroJitter = { baseDuration: 5000, jitterRange: 0 };
+    for (let seed = 0; seed < 200; seed++) {
+      const result = runGame({ seed, timingConfig: zeroJitter });
+      if (result.outcome === 'win') {
+        const levelCompletes = result.transcript.events.filter(
+          (e) => e.type === 'level-complete',
+        );
+        // All 8 levels completed — each produces a level-complete event
+        expect(levelCompletes.length).toBe(8);
+        return;
+      }
+    }
+    // If no win found, skip
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple runs (statistical sanity)
+// ---------------------------------------------------------------------------
+
+describe('headless runGame — multiple seeds', () => {
+  it('can run 100 games without errors', () => {
+    for (let seed = 0; seed < 100; seed++) {
+      expect(() => runSeeded(seed)).not.toThrow();
+    }
+  });
+
+  it('produces both wins and losses across seeds', () => {
+    let wins = 0;
+    let losses = 0;
+
+    // Default jitter produces mostly losses
+    for (let seed = 0; seed < 100; seed++) {
+      const result = runSeeded(seed);
+      if (result.outcome === 'win') wins++;
+      else losses++;
+    }
+
+    // Zero jitter produces mostly wins
+    const zeroJitter = { baseDuration: 5000, jitterRange: 0 };
+    for (let seed = 0; seed < 100; seed++) {
+      const result = runGame({ seed, timingConfig: zeroJitter });
+      if (result.outcome === 'win') wins++;
+      else losses++;
+    }
+
+    expect(wins).toBeGreaterThan(0);
+    expect(losses).toBeGreaterThan(0);
+  });
+
+  it('total plays are reasonable (not infinite loops)', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const result = runSeeded(seed);
+      // Max possible plays: 8 levels, up to 8 cards each = 2*8*8 = 128 cards
+      // But penalty discards reduce this. Should never exceed 128.
+      expect(result.totalPlays).toBeLessThanOrEqual(128);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('headless runGame — edge cases', () => {
+  it('zero jitter produces fully deterministic play order', () => {
+    const config: HeadlessGameConfig = {
+      seed: 99,
+      timingConfig: { baseDuration: 5000, jitterRange: 0 },
+    };
+
+    const a = runGame(config);
+    const b = runGame(config);
+
+    // With zero jitter, the exact sequence of plays should be identical
+    const aPlayValues = a.transcript.events
+      .filter((e) => e.type === 'card-played')
+      .map((e) => (e as { cardValue: number }).cardValue);
+    const bPlayValues = b.transcript.events
+      .filter((e) => e.type === 'card-played')
+      .map((e) => (e as { cardValue: number }).cardValue);
+
+    expect(aPlayValues).toEqual(bPlayValues);
+  });
+
+  it('very short base duration still produces valid games', () => {
+    const result = runGame({
+      seed: 42,
+      timingConfig: { baseDuration: 10, jitterRange: 0 },
+    });
+    expect(['win', 'loss']).toContain(result.outcome);
+    expect(result.totalPlays).toBeGreaterThan(0);
+  });
+
+  it('very long base duration still produces valid games', () => {
+    const result = runGame({
+      seed: 42,
+      timingConfig: { baseDuration: 100000, jitterRange: 0 },
+    });
+    expect(['win', 'loss']).toContain(result.outcome);
+    expect(result.totalPlays).toBeGreaterThan(0);
+  });
+
+  it('high jitter still produces valid games', () => {
+    const result = runGame({
+      seed: 42,
+      timingConfig: { baseDuration: 5000, jitterRange: 4000 },
+    });
+    expect(['win', 'loss']).toContain(result.outcome);
+    expect(result.totalPlays).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Headless game runner** (`headlessGame.ts`): `runGame(config?)` simulates complete AI-vs-AI games without Phaser. Returns transcript, stats, and outcome. Uses seeded RNGs for full determinism.
- **Auto-play toggle** in `TheMindScene`: bottom-left button enables/disables spectator mode mid-game. When enabled, a second `MindAiPlayer` drives the human player's cards via timing strategy.
- **URL parameter** `?autoplay=true` starts the scene in spectator mode automatically.
- **Bug fix**: headless runner now correctly records level-complete events for the final level (level 8) before the game-over event.
- **33 new tests** covering determinism, configuration, transcript structure, statistical behavior, and edge cases.

## Files Changed

- `example-games/the-mind/headlessGame.ts` (new) — headless AI-vs-AI runner
- `example-games/the-mind/scenes/TheMindScene.ts` — auto-play toggle, human AI player, URL param support
- `tests/the-mind/auto-play.test.ts` (new) — 33 unit tests

## Testing

- `npm run build` — passes
- `npx vitest run --project unit` — 1294 tests pass (33 new)

## Work Item

CG-0MLZSLMEL0WJDTPZ (Feature 7: Auto-Play Spectator Mode)