### PR TITLE
CG-0MM006WRG04K5FW6: Enlarge cards, add help panel, fix header overlap

### DIFF
--- a/example-games/the-mind/help-content.json
+++ b/example-games/the-mind/help-content.json
@@ -1,0 +1,34 @@
+[
+  {
+    "heading": "The Mind",
+    "body": "A cooperative card game where you and an AI partner play numbered cards (1-100) onto a shared ascending pile -- without taking turns or communicating. Both players can play at any time. The challenge is timing: play your cards in the right order by feeling when the moment is right."
+  },
+  {
+    "heading": "How to Play",
+    "body": "Cards must be played in ascending order onto the pile. You can see your own cards (face-up) but not the AI's cards (face-down). Click any card in your hand to play it.\n\nThere are no turns -- both you and the AI can play at any time. The AI uses internal timing to decide when to play. If you think the AI has a lower card, wait. If your lowest card feels safe, play it."
+  },
+  {
+    "heading": "Levels",
+    "body": "The game has 8 levels. At level 1, each player receives 1 card. At level 2, each player receives 2 cards, and so on up to 8 cards each at level 8.\n\nComplete a level by playing all cards from both hands in ascending order. After completing level 3, you earn a bonus life."
+  },
+  {
+    "heading": "Lives & Penalties",
+    "body": "You start with 2 lives (max 3). If a card is played out of order -- meaning the other player was holding a lower card -- a life is lost. All cards lower than the played card are discarded as a penalty.\n\nWhen all lives are lost, the game is over. Complete all 8 levels to win!"
+  },
+  {
+    "heading": "The Pile",
+    "body": "The pile in the centre of the screen shows the last card played and a running count. Cards must always be played in ascending order -- you cannot play a card with a value lower than or equal to the top of the pile."
+  },
+  {
+    "heading": "Auto-Play Mode",
+    "body": "Click the Auto-Play toggle (bottom-left) to let a second AI control your hand. Watch two AIs play a full game cooperatively. Toggle it off at any time to resume manual play."
+  },
+  {
+    "heading": "Tips",
+    "body": "- If your lowest card is close to the pile's top value, play it quickly.\n- If there is a large gap between the pile and your lowest card, wait -- the AI may have cards in between.\n- Watch the AI's card count. Fewer cards means less risk of a penalty.\n- Pay attention to the pace of AI plays to develop a sense of its timing rhythm."
+  },
+  {
+    "heading": "Controls",
+    "body": "Click a card in your hand to play it.\n\nPress ? to toggle this help panel.\nPress Escape to toggle the settings panel."
+  }
+]

--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -47,7 +47,11 @@ import {
   createSceneHeader,
   SettingsPanel,
   SettingsButton,
+  HelpPanel,
+  HelpButton,
 } from '../../../src/ui';
+import type { HelpSection } from '../../../src/ui';
+import helpContent from '../help-content.json';
 
 // ── Audio asset keys ────────────────────────────────────────
 const SFX_KEYS = {
@@ -61,18 +65,19 @@ const SFX_KEYS = {
 
 // ── Constants ───────────────────────────────────────────────
 
-// Card display dimensions (larger than default for playability)
-const CARD_W = 80;
-const CARD_H = 109;
+// Card display dimensions (~50% larger than default for readability)
+const CARD_W = 120;
+const CARD_H = 164;
 
 // Layout
 const PILE_X = GAME_W / 2;
-const PILE_Y = GAME_H / 2 - 30;
+const PILE_Y = GAME_H / 2 - 10;
 
-const HUMAN_HAND_Y = GAME_H - 90;
-const AI_HAND_Y = 80;
+const HUMAN_HAND_Y = GAME_H - 110;
+const AI_HAND_Y = 150;
 
 const CARD_GAP = 8;
+const MAX_HAND_WIDTH = GAME_W - 80; // leave 40px margin each side
 
 // Timing
 const LEVEL_COMPLETE_DELAY = 2000;
@@ -128,6 +133,10 @@ export class TheMindScene extends Phaser.Scene {
   private soundManager: SoundManager | null = null;
   private settingsPanel!: SettingsPanel;
   private settingsButton!: SettingsButton;
+
+  // Help system
+  private helpPanel!: HelpPanel;
+  private helpButton!: HelpButton;
 
   // Display objects -- human hand
   private humanCardSprites: Phaser.GameObjects.Image[] = [];
@@ -205,6 +214,7 @@ export class TheMindScene extends Phaser.Scene {
     this.createPile();
     this.createInstruction();
     this.createAutoPlayButton();
+    this.createHelpPanel();
 
     // Initial render
     this.renderHumanHand();
@@ -223,24 +233,24 @@ export class TheMindScene extends Phaser.Scene {
   }
 
   private createStatusDisplay(): void {
-    // Level indicator (top-right area)
+    // Level indicator (top-right area, clear of settings/help buttons)
     this.levelText = this.add
-      .text(GAME_W - 20, 10, '', {
+      .text(GAME_W - 100, 10, '', {
         fontSize: '16px',
         color: '#aaccff',
         fontFamily: FONT_FAMILY,
       })
-      .setOrigin(1, 0)
+      .setOrigin(0.5, 0)
       .setDepth(DEPTH_UI);
 
     // Lives display (below level)
     this.livesText = this.add
-      .text(GAME_W - 20, 34, '', {
+      .text(GAME_W - 100, 34, '', {
         fontSize: '16px',
         color: '#ff6666',
         fontFamily: FONT_FAMILY,
       })
-      .setOrigin(1, 0)
+      .setOrigin(0.5, 0)
       .setDepth(DEPTH_UI);
   }
 
@@ -320,6 +330,15 @@ export class TheMindScene extends Phaser.Scene {
       soundManager: this.soundManager,
     });
     this.settingsButton = new SettingsButton(this, this.settingsPanel);
+  }
+
+  // ── Help panel ─────────────────────────────────────────
+
+  private createHelpPanel(): void {
+    this.helpPanel = new HelpPanel(this, {
+      sections: helpContent as HelpSection[],
+    });
+    this.helpButton = new HelpButton(this, this.helpPanel);
   }
 
   // ── Auto-play spectator mode ───────────────────────────
@@ -451,18 +470,25 @@ export class TheMindScene extends Phaser.Scene {
     const hand = this.session.players[0].hand;
     if (hand.length === 0) return;
 
-    const totalWidth = hand.length * CARD_W + (hand.length - 1) * CARD_GAP;
-    const startX = (GAME_W - totalWidth) / 2 + CARD_W / 2;
+    // Dynamic spacing: overlap cards if they exceed MAX_HAND_WIDTH
+    const idealWidth = hand.length * CARD_W + (hand.length - 1) * CARD_GAP;
+    const step = idealWidth <= MAX_HAND_WIDTH
+      ? CARD_W + CARD_GAP
+      : (MAX_HAND_WIDTH - CARD_W) / (hand.length - 1 || 1);
+    const actualWidth = hand.length === 1
+      ? CARD_W
+      : CARD_W + (hand.length - 1) * step;
+    const startX = (GAME_W - actualWidth) / 2 + CARD_W / 2;
 
     for (let i = 0; i < hand.length; i++) {
       const card = hand[i];
       // Human cards are always face-up
       const displayCard = { ...card, faceUp: true };
-      const x = startX + i * (CARD_W + CARD_GAP);
+      const x = startX + i * step;
       const sprite = this.add
         .image(x, HUMAN_HAND_Y, getMindCardTexture(displayCard))
         .setDisplaySize(CARD_W, CARD_H)
-        .setDepth(DEPTH_CARDS)
+        .setDepth(DEPTH_CARDS + i) // later cards render on top when overlapping
         .setInteractive({ useHandCursor: true });
 
       // Click handler
@@ -525,15 +551,22 @@ export class TheMindScene extends Phaser.Scene {
       return;
     }
 
-    const totalWidth = hand.length * CARD_W + (hand.length - 1) * CARD_GAP;
-    const startX = (GAME_W - totalWidth) / 2 + CARD_W / 2;
+    // Dynamic spacing: overlap cards if they exceed MAX_HAND_WIDTH
+    const idealWidth = hand.length * CARD_W + (hand.length - 1) * CARD_GAP;
+    const step = idealWidth <= MAX_HAND_WIDTH
+      ? CARD_W + CARD_GAP
+      : (MAX_HAND_WIDTH - CARD_W) / (hand.length - 1 || 1);
+    const actualWidth = hand.length === 1
+      ? CARD_W
+      : CARD_W + (hand.length - 1) * step;
+    const startX = (GAME_W - actualWidth) / 2 + CARD_W / 2;
 
     for (let i = 0; i < hand.length; i++) {
-      const x = startX + i * (CARD_W + CARD_GAP);
+      const x = startX + i * step;
       const sprite = this.add
         .image(x, AI_HAND_Y, CARD_BACK_KEY)
         .setDisplaySize(CARD_W, CARD_H)
-        .setDepth(DEPTH_CARDS);
+        .setDepth(DEPTH_CARDS + i); // later cards render on top when overlapping
 
       this.aiCardSprites.push(sprite);
     }
@@ -1309,6 +1342,8 @@ export class TheMindScene extends Phaser.Scene {
     this.gameEvents?.removeAllListeners();
     this.settingsPanel?.destroy();
     this.settingsButton?.destroy();
+    this.helpPanel?.destroy();
+    this.helpButton?.destroy();
 
     // Clean up overlay objects
     for (const obj of this.overlayObjects) {


### PR DESCRIPTION
## Summary

Three visual improvements to The Mind scene:

- **Cards enlarged by 50%** (80x109 -> 120x164) for better readability. Layout constants adjusted accordingly (AI hand y=150, human hand y=610, pile y=350). Hand spacing is now dynamic with a MAX_HAND_WIDTH cap so cards overlap gracefully at higher levels instead of exceeding the viewport. Depth layering per card index ensures overlapping cards stack correctly.

- **Help panel added** via the reusable HelpPanel/HelpButton system already used by all other example games. The Mind was the only game without one. Includes 8 sections covering rules, levels, lives, penalties, auto-play mode, tips, and controls. Accessible via the ? button (top-right) or the ? keyboard shortcut.

- **Header overlap fixed** by repositioning the level/lives status text from x=GAME_W-20 (right-aligned) to x=GAME_W-100 (center-anchored), clearing the settings gear icon (x=1200) and help button (x=1248).

## Changes

- `example-games/the-mind/scenes/TheMindScene.ts` (+69/-19 lines)
- `example-games/the-mind/help-content.json` (new, 34 lines)

## Testing

- All 1327 unit tests pass across 57 files
- `npm run build` succeeds

## Work Item

CG-0MM006WRG04K5FW6