### PR TITLE
CG-0MM00LGEU0IM99ZC: Fix game-over overlay buttons

### DIFF
--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -89,8 +89,8 @@ const DEPTH_CARDS = 1;
 const DEPTH_PILE = 2;
 const DEPTH_PLAYED_CARD = 3;
 const DEPTH_UI = 5;
-const DEPTH_OVERLAY = 10;
-const DEPTH_OVERLAY_CONTENT = 11;
+const DEPTH_OVERLAY = 2000;
+const DEPTH_OVERLAY_CONTENT = DEPTH_OVERLAY + 1;
 
 // ── Phase state machine ─────────────────────────────────────
 
@@ -1087,6 +1087,7 @@ export class TheMindScene extends Phaser.Scene {
   private handleGameOver(): void {
     this.cancelAiTimer();
     this.cancelHumanAiTimer();
+    this.disableGameInteraction();
 
     const timestamp = Date.now() - this.levelStartTime;
     const outcome = this.session.outcome as 'win' | 'loss';
@@ -1113,6 +1114,16 @@ export class TheMindScene extends Phaser.Scene {
       this.showWinOverlay();
     } else {
       this.showLossOverlay();
+    }
+  }
+
+  /** Disable all game-element interactivity so the overlay buttons receive clicks. */
+  private disableGameInteraction(): void {
+    for (const sprite of this.humanCardSprites) {
+      sprite.disableInteractive();
+    }
+    if (this.autoPlayButton) {
+      this.autoPlayButton.disableInteractive();
     }
   }
 


### PR DESCRIPTION
## Summary
- Raises overlay depths from 10/11 to 2000/2001, matching the proven Beleaguered Castle pattern, so overlay buttons render and receive input above all other scene elements (card sprites at depths 1-8, auto-play button at depth 5, help/settings panels at depths 900-904)
- Disables interactive on human card sprites and the auto-play button when the game-over overlay appears, preventing any stale hit-testing interference from lower-depth interactive objects

## Context
PR #24 attempted to fix the game-over button bug with shutdown lifecycle registration, deferred scene transitions, and button refactoring — but the buttons remained non-functional. Deep investigation revealed the root cause: the overlay depth values (10/11) were too close to other interactive elements, and game elements remained interactive underneath the overlay. Beleaguered Castle uses depths 2000/2001 and its buttons work correctly.

## Changes
- `example-games/the-mind/scenes/TheMindScene.ts`:
  - `DEPTH_OVERLAY`: 10 → 2000
  - `DEPTH_OVERLAY_CONTENT`: 11 → 2001 (computed as `DEPTH_OVERLAY + 1`)
  - Added `disableGameInteraction()` method that disables interactive on all human card sprites and the auto-play button
  - Called `disableGameInteraction()` from `handleGameOver()` before showing overlays

## Testing
- All 1332 unit tests pass
- TypeScript compilation clean (no new errors)

## Work Item
CG-0MM00LGEU0IM99ZC