### PR TITLE
CG-0MM00LGEU0IM99ZC: Fix Text drawImage crash

### DIFF
--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -142,7 +142,7 @@ export class TheMindScene extends Phaser.Scene {
 
   // Display objects -- AI hand
   private aiCardSprites: Phaser.GameObjects.Image[] = [];
-  private aiCountText!: Phaser.GameObjects.Text;
+  private aiCountText: Phaser.GameObjects.Text | null = null;
 
   // Display objects -- pile
   private pileSprite!: Phaser.GameObjects.Image;
@@ -183,7 +183,8 @@ export class TheMindScene extends Phaser.Scene {
     // Register shutdown lifecycle so custom cleanup runs on scene.restart()
     this.events.on('shutdown', this.shutdown, this);
 
-    // Reset state for scene restart
+    // Reset state for scene restart (clear stale refs from previous run;
+    // Phaser destroys game objects on restart but class fields survive).
     this.phase = 'dealing';
     this.humanCardSprites = [];
     this.aiCardSprites = [];
@@ -191,6 +192,7 @@ export class TheMindScene extends Phaser.Scene {
     this.aiTimer = null;
     this.humanAiTimer = null;
     this.turnCounter = 0;
+    this.aiCountText = null;
 
     // Check URL parameter for auto-play
     const urlParams = new URLSearchParams(window.location.search);
@@ -574,17 +576,19 @@ export class TheMindScene extends Phaser.Scene {
       this.aiCardSprites.push(sprite);
     }
 
-    // Count indicator
-    if (!this.aiCountText) {
-      this.aiCountText = this.add
-        .text(GAME_W / 2, AI_HAND_Y + CARD_H / 2 + 14, '', {
-          fontSize: '12px',
-          color: '#aaaaaa',
-          fontFamily: FONT_FAMILY,
-        })
-        .setOrigin(0.5)
-        .setDepth(DEPTH_UI);
+    // Count indicator — always recreate (previous instance is destroyed on
+    // scene restart, leaving a stale reference).
+    if (this.aiCountText) {
+      this.aiCountText.destroy();
     }
+    this.aiCountText = this.add
+      .text(GAME_W / 2, AI_HAND_Y + CARD_H / 2 + 14, '', {
+        fontSize: '12px',
+        color: '#aaaaaa',
+        fontFamily: FONT_FAMILY,
+      })
+      .setOrigin(0.5)
+      .setDepth(DEPTH_UI);
 
     this.aiCountText.setText(
       `AI: ${hand.length} card${hand.length !== 1 ? 's' : ''}`,

--- a/src/ui/hiDpiText.ts
+++ b/src/ui/hiDpiText.ts
@@ -49,11 +49,13 @@ if (!TextProto[PATCHED]) {
     this: Phaser.GameObjects.Text,
   ) {
     // Upgrade resolution only when it's still at the Phaser default.
+    // Only set style.resolution here -- Phaser's updateText will
+    // propagate it to the frame/source internally after it renders
+    // the text canvas. Setting frame.source.resolution directly
+    // before updateText can cause a null-source crash when Phaser
+    // tries to resize the frame before the canvas is ready.
     if (this.style.resolution === 1) {
       this.style.resolution = TEXT_DPR;
-      if (this.frame?.source) {
-        this.frame.source.resolution = TEXT_DPR;
-      }
     }
 
     return origUpdateText.call(this);


### PR DESCRIPTION
## Summary
- Fixes `Cannot read properties of null (reading 'drawImage')` crash in Phaser Text objects
- Addresses two root causes: stale `aiCountText` reference on scene restart, and premature `frame.source.resolution` mutation in the hiDpiText patch

## Root Cause Analysis

**Error trace:**
```
Frame2.updateUVs -> drawImage on null
Frame2.setCutPosition -> updateUVs
Frame2.setSize -> setCutPosition
Text2.updateText -> setSize
hiDpiText.ts:59 -> origUpdateText.call(this)
TheMindScene.renderAiHand -> aiCountText.setText(...)
TheMindScene.create
```

**Two contributing issues:**

1. **Stale `aiCountText` reference** (`TheMindScene.ts`): On `scene.restart()`, Phaser destroys all game objects but class instance fields survive. The `aiCountText` field held a reference to the destroyed Text object. `renderAiHand()` checked `if (!this.aiCountText)` to skip recreation, but the destroyed object was still truthy, causing `setText()` to be called on a dead Text with a null internal canvas.

2. **Premature `frame.source.resolution` mutation** (`hiDpiText.ts`): The HiDPI patch was setting `this.frame.source.resolution = TEXT_DPR` before calling the original `updateText()`. This could race with Phaser's internal canvas setup — the frame source might not be fully initialized yet when the resolution is changed, leading to null references during the subsequent canvas-to-texture pipeline.

## Changes

- `example-games/the-mind/scenes/TheMindScene.ts`:
  - Changed `aiCountText` field from `!:` (definite assignment) to `| null = null` (nullable)
  - Reset `aiCountText = null` in `create()` during restart cleanup
  - Always destroy and recreate the Text object in `renderAiHand()` instead of conditionally reusing

- `src/ui/hiDpiText.ts`:
  - Removed `this.frame.source.resolution = TEXT_DPR` assignment
  - Only sets `this.style.resolution = TEXT_DPR` — Phaser propagates this to the frame internally during `updateText()`

## Testing
- All 1332 unit tests pass
- All 4 TheMind overlay browser tests pass
- TypeScript compilation clean

## Work Item
CG-0MM00LGEU0IM99ZC