### PR TITLE
CG-0MM0363M211AU67D: AI fast-play when last card and opponent hand empty

### DIFF
--- a/example-games/the-mind/AiStrategy.ts
+++ b/example-games/the-mind/AiStrategy.ts
@@ -35,6 +35,33 @@ export const DEFAULT_JITTER_RANGE = 800;
 /** Minimum delay in ms — prevents the AI from playing instantly. */
 export const MIN_PLAY_DELAY = 1500;
 
+/**
+ * Short delay (ms) used when a player has only one card left and the
+ * other player's hand is already empty.  There is no decision to make in
+ * this situation so a long wait feels unnatural.
+ */
+export const AI_LAST_CARD_DELAY = 400;
+
+/**
+ * Compute the effective AI play delay for a scheduled card.
+ *
+ * When the opponent's hand is empty and this player has exactly one card
+ * remaining, returns {@link AI_LAST_CARD_DELAY} so the obvious play happens
+ * quickly.  Otherwise falls back to the normal elapsed-time calculation
+ * (clamped to a 100 ms floor).
+ */
+export function computeEffectiveDelay(
+  committedDelay: number,
+  elapsedSinceLevelStart: number,
+  playerHandSize: number,
+  opponentHandSize: number,
+): number {
+  if (opponentHandSize === 0 && playerHandSize === 1) {
+    return AI_LAST_CARD_DELAY;
+  }
+  return Math.max(committedDelay - elapsedSinceLevelStart, 100);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -25,7 +25,7 @@ import {
   getPileTopValue,
   MAX_LEVEL,
 } from '../TheMindGameState';
-import { MindAiPlayer } from '../AiStrategy';
+import { MindAiPlayer, computeEffectiveDelay } from '../AiStrategy';
 import {
   preloadMindCardAssets,
   getMindCardTexture,
@@ -416,7 +416,12 @@ export class TheMindScene extends Phaser.Scene {
     if (!nextCard) return;
 
     const elapsed = Date.now() - this.aiLevelStartTime;
-    const delay = Math.max(nextCard.delay - elapsed, 100);
+    const delay = computeEffectiveDelay(
+      nextCard.delay,
+      elapsed,
+      this.session.players[0].hand.length, // human-AI (this player)
+      this.session.players[1].hand.length, // AI (opponent)
+    );
 
     this.humanAiTimer = this.time.delayedCall(delay, () => {
       if (this.phase !== 'playing') return;
@@ -1309,9 +1314,13 @@ export class TheMindScene extends Phaser.Scene {
     const nextCard = this.aiPlayer.getNextCard();
     if (!nextCard) return;
 
-    // Calculate delay from now: the committed delay is relative to level start
     const elapsed = Date.now() - this.aiLevelStartTime;
-    const delay = Math.max(nextCard.delay - elapsed, 100);
+    const delay = computeEffectiveDelay(
+      nextCard.delay,
+      elapsed,
+      this.session.players[1].hand.length, // AI (this player)
+      this.session.players[0].hand.length, // human (opponent)
+    );
 
     this.aiTimer = this.time.delayedCall(delay, () => {
       if (this.phase !== 'playing') return;

--- a/tests/the-mind/ai-strategy.test.ts
+++ b/tests/the-mind/ai-strategy.test.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_BASE_DURATION,
   DEFAULT_JITTER_RANGE,
   MIN_PLAY_DELAY,
+  AI_LAST_CARD_DELAY,
+  computeEffectiveDelay,
 } from '../../example-games/the-mind/AiStrategy';
 import type { MindCard } from '../../example-games/the-mind/MindCard';
 import { createSeededRng } from '../../src/core-engine/SeededRng';
@@ -716,5 +718,92 @@ describe('MindAiPlayer', () => {
         }
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEffectiveDelay — fast-play when last card & opponent empty
+// ---------------------------------------------------------------------------
+
+describe('computeEffectiveDelay', () => {
+  it('AI_LAST_CARD_DELAY is 400ms', () => {
+    expect(AI_LAST_CARD_DELAY).toBe(400);
+  });
+
+  it('returns AI_LAST_CARD_DELAY when opponent hand is empty and player has 1 card', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 8000,
+      /* elapsed */ 2000,
+      /* playerHandSize */ 1,
+      /* opponentHandSize */ 0,
+    );
+    expect(result).toBe(AI_LAST_CARD_DELAY);
+  });
+
+  it('returns normal delay when opponent still has cards (even if player has 1 card)', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 8000,
+      /* elapsed */ 2000,
+      /* playerHandSize */ 1,
+      /* opponentHandSize */ 2,
+    );
+    // Normal: max(8000 - 2000, 100) = 6000
+    expect(result).toBe(6000);
+  });
+
+  it('returns normal delay when player has more than 1 card (even if opponent hand is empty)', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 8000,
+      /* elapsed */ 2000,
+      /* playerHandSize */ 3,
+      /* opponentHandSize */ 0,
+    );
+    // Normal: max(8000 - 2000, 100) = 6000
+    expect(result).toBe(6000);
+  });
+
+  it('returns normal delay when both players have cards', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 5000,
+      /* elapsed */ 1000,
+      /* playerHandSize */ 2,
+      /* opponentHandSize */ 3,
+    );
+    // Normal: max(5000 - 1000, 100) = 4000
+    expect(result).toBe(4000);
+  });
+
+  it('clamps normal delay to 100ms minimum', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 3000,
+      /* elapsed */ 5000,
+      /* playerHandSize */ 2,
+      /* opponentHandSize */ 1,
+    );
+    // Normal: max(3000 - 5000, 100) = max(-2000, 100) = 100
+    expect(result).toBe(100);
+  });
+
+  it('does not clamp to 100ms in fast-play scenario (AI_LAST_CARD_DELAY is used directly)', () => {
+    // Even if the committed delay minus elapsed would be negative,
+    // the fast-play path returns AI_LAST_CARD_DELAY, not 100.
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 1000,
+      /* elapsed */ 5000,
+      /* playerHandSize */ 1,
+      /* opponentHandSize */ 0,
+    );
+    expect(result).toBe(AI_LAST_CARD_DELAY);
+  });
+
+  it('returns normal delay when both hands are empty (edge case)', () => {
+    const result = computeEffectiveDelay(
+      /* committedDelay */ 5000,
+      /* elapsed */ 1000,
+      /* playerHandSize */ 0,
+      /* opponentHandSize */ 0,
+    );
+    // playerHandSize is 0, not 1, so normal path
+    expect(result).toBe(4000);
   });
 });


### PR DESCRIPTION
## Summary

When the AI has only one card remaining and the human player's hand is empty, the AI now plays its last card after a short 400ms delay instead of waiting for the full computed timing delay. There is no decision to make in this situation, so the long wait felt unnatural.

The same logic applies symmetrically in auto-play mode when the human-AI has one card and the real AI's hand is empty.

## Changes

- **`AiStrategy.ts`**: Added `AI_LAST_CARD_DELAY` (400ms) constant and `computeEffectiveDelay()` pure function that encapsulates the delay decision logic
- **`TheMindScene.ts`**: Updated `scheduleAiPlay()` and `scheduleHumanAiPlay()` to use `computeEffectiveDelay()` with both players' hand sizes
- **`ai-strategy.test.ts`**: Added 8 unit tests covering all branches (fast-play trigger, normal delay, clamping, edge cases)

## Testing

- 1340 unit tests pass (56 in ai-strategy.test.ts, up from 48)
- TypeScript compiles clean
- No changes to existing test assertions

## Work Item

CG-0MM0363M211AU67D