### PR TITLE
CG-0MM03ITUF1SKCSOZ: Fix Golf browser test failures in CI

### DIFF
--- a/example-games/golf/scenes/GolfScene.ts
+++ b/example-games/golf/scenes/GolfScene.ts
@@ -753,6 +753,8 @@ export class GolfScene extends Phaser.Scene {
       this.discardSprite.setVisible(true);
       this.discardSprite.setTexture(getCardTexture(top));
       this.discardSprite.setAlpha(1);
+    } else if (this.replayMode) {
+      this.discardSprite.setVisible(false);
     } else {
       this.showDiscardPlaceholder();
     }

--- a/tests/golf/GolfInteraction.browser.test.ts
+++ b/tests/golf/GolfInteraction.browser.test.ts
@@ -347,7 +347,7 @@ describe('GolfScene interaction tests', () => {
 
     // Discard the drawn card
     clickGameObject(internals.discardSprite);
-    await nextFrame();
+    await waitForPhaseChange(scene, 'animating', 3000);
 
     expect(internals.turnPhase).toBe('waiting-for-flip-target');
     expect(internals.instructionText.text).toContain('face-down');


### PR DESCRIPTION
## Summary

Fixes two Golf browser tests that fail consistently in CI (GitHub Actions) while passing locally.

- **Fix 1 (GolfInteraction.browser.test.ts:349)**: Replace `await nextFrame()` with `await waitForPhaseChange(scene, 'animating', 3000)` after clicking discard. The discard animation takes 225ms (`SWAP_ANIM_DURATION / 2`) and the phase only transitions in the tween's `onComplete` callback. A single frame (~16ms) is never enough in CI. The `waitForPhaseChange` helper (already used elsewhere in the same file) polls every 50ms until the phase changes.

- **Fix 2 (GolfScene.ts:756)**: In `refreshPiles()`, when the discard pile is empty and the scene is in replay mode, hide the discard sprite entirely instead of showing the dimmed placeholder. The placeholder (`showDiscardPlaceholder`) sets `visible = true` with a card-back texture at 25% alpha — correct for normal gameplay (keeps discard area clickable) but wrong for replay mode where the test expects `visible === false`.

## Verification

- Both previously-failing tests now pass locally in the browser test runner
- All unit tests pass (`npx vitest run --project unit`)
- TypeScript compilation clean (`npx tsc --noEmit`)

## Work Item

CG-0MM03ITUF1SKCSOZ