### PR TITLE
CG-0MM041HC70G1UFSH: Fix top-line UI overlap with settings/help buttons

### DIFF
--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -238,9 +238,9 @@ export class TheMindScene extends Phaser.Scene {
   }
 
   private createStatusDisplay(): void {
-    // Level indicator (top-right area, clear of settings/help buttons)
+    // Level indicator (top-right area, below settings/help buttons)
     this.levelText = this.add
-      .text(GAME_W - 100, 10, '', {
+      .text(GAME_W - 100, 55, '', {
         fontSize: '16px',
         color: '#aaccff',
         fontFamily: FONT_FAMILY,
@@ -250,7 +250,7 @@ export class TheMindScene extends Phaser.Scene {
 
     // Lives display (below level)
     this.livesText = this.add
-      .text(GAME_W - 100, 34, '', {
+      .text(GAME_W - 100, 79, '', {
         fontSize: '16px',
         color: '#ff6666',
         fontFamily: FONT_FAMILY,


### PR DESCRIPTION
## Summary

- Moves the level and lives status text down to avoid overlapping with the settings and help buttons in the top-right corner of TheMindScene.
- Level text moved from y=10 to y=55, lives text from y=34 to y=79. The settings/help buttons extend down to y=48 (centered at y=32 with radius 16), so this places the status text comfortably below them.

## Work Item

CG-0MM041HC70G1UFSH