### PR TITLE
CG-0MMJ8S87N06Q5GP1: Difficulty Presets (Easy/Medium/Hard) for Main Street

### DIFF
--- a/example-games/main-street/MainStreetAdjacency.ts
+++ b/example-games/main-street/MainStreetAdjacency.ts
@@ -39,17 +39,19 @@ export function neighbors(index: number, range: number = 1): number[] {
 /**
  * Computes the synergy bonus for a single business at a given slot.
  *
- * A business earns +SYNERGY_BONUS_PER_NEIGHBOR coins for each neighboring
+ * A business earns +bonusPerNeighbor coins for each neighboring
  * slot that contains a business sharing at least one SynergyType.
  * The range considered is 1 + business.synergyRangeBonus (from upgrades).
  *
- * @param grid   The street grid.
- * @param index  The slot index of the business.
+ * @param grid               The street grid.
+ * @param index              The slot index of the business.
+ * @param bonusPerNeighbor   Coins per matching neighbor (defaults to SYNERGY_BONUS_PER_NEIGHBOR for backward compat).
  * @returns The synergy bonus in coins.
  */
 export function computeSynergyBonus(
   grid: (BusinessCard | null)[],
   index: number,
+  bonusPerNeighbor: number = SYNERGY_BONUS_PER_NEIGHBOR,
 ): number {
   const business = grid[index];
   if (!business) return 0;
@@ -67,7 +69,7 @@ export function computeSynergyBonus(
       (st: SynergyType) => neighbor.synergyTypes.includes(st),
     );
     if (hasSharedSynergy) {
-      bonus += SYNERGY_BONUS_PER_NEIGHBOR;
+      bonus += bonusPerNeighbor;
     }
   }
 
@@ -79,19 +81,21 @@ export function computeSynergyBonus(
  *
  * totalIncome = baseIncome + incomeBonus (from upgrades) + synergyBonus
  *
- * @param grid   The street grid.
- * @param index  The slot index of the business.
+ * @param grid               The street grid.
+ * @param index              The slot index of the business.
+ * @param bonusPerNeighbor   Coins per matching neighbor (defaults to SYNERGY_BONUS_PER_NEIGHBOR).
  * @returns The total income in coins for this business.
  */
 export function computeBusinessIncome(
   grid: (BusinessCard | null)[],
   index: number,
+  bonusPerNeighbor: number = SYNERGY_BONUS_PER_NEIGHBOR,
 ): number {
   const business = grid[index];
   if (!business) return 0;
 
   const base = business.baseIncome + business.incomeBonus;
-  const synergy = computeSynergyBonus(grid, index);
+  const synergy = computeSynergyBonus(grid, index, bonusPerNeighbor);
   return base + synergy;
 }
 
@@ -100,10 +104,14 @@ export function computeBusinessIncome(
  *
  * Returns both the total and a per-slot breakdown for UI display.
  *
- * @param grid  The street grid.
+ * @param grid               The street grid.
+ * @param bonusPerNeighbor   Coins per matching neighbor (defaults to SYNERGY_BONUS_PER_NEIGHBOR).
  * @returns Object with `total` income and `breakdown` per slot.
  */
-export function computeIncome(grid: (BusinessCard | null)[]): IncomeResult {
+export function computeIncome(
+  grid: (BusinessCard | null)[],
+  bonusPerNeighbor: number = SYNERGY_BONUS_PER_NEIGHBOR,
+): IncomeResult {
   const breakdown: SlotIncome[] = [];
   let total = 0;
 
@@ -112,7 +120,7 @@ export function computeIncome(grid: (BusinessCard | null)[]): IncomeResult {
     if (!business) continue;
 
     const base = business.baseIncome + business.incomeBonus;
-    const synergy = computeSynergyBonus(grid, i);
+    const synergy = computeSynergyBonus(grid, i, bonusPerNeighbor);
     const slotTotal = base + synergy;
 
     breakdown.push({
@@ -131,13 +139,14 @@ export function computeIncome(grid: (BusinessCard | null)[]): IncomeResult {
 
 /**
  * Applies income to the player's resource bank.
- * Mutates state in-place.
+ * Mutates state in-place. Uses config.synergyBonusPerNeighbor from the
+ * active difficulty preset.
  *
  * @param state  Current game state (mutated).
  * @returns The IncomeResult for UI display.
  */
 export function applyIncome(state: MainStreetState): IncomeResult {
-  const result = computeIncome(state.streetGrid);
+  const result = computeIncome(state.streetGrid, state.config.synergyBonusPerNeighbor);
   state.resourceBank.coins += result.total;
   if (result.total > 0) {
     addLog(state, `Income: +${result.total} coins`, 'gain');

--- a/example-games/main-street/MainStreetDifficulty.ts
+++ b/example-games/main-street/MainStreetDifficulty.ts
@@ -1,0 +1,132 @@
+/**
+ * Main Street: Difficulty Presets
+ *
+ * Defines named difficulty configurations that parameterize the game's
+ * economy, turn structure, and challenge settings. The Medium preset
+ * exactly matches the original hard-coded constants for backward
+ * compatibility.
+ *
+ * Presets are selected at game setup and stored in `MainStreetState.config`.
+ * All engine, adjacency, scoring, and challenge code reads from the config
+ * rather than module-level constants.
+ *
+ * @module
+ */
+
+// ── Difficulty Names ────────────────────────────────────────
+
+/** The available named difficulty levels. */
+export type DifficultyName = 'Easy' | 'Medium' | 'Hard';
+
+// ── Game Config Interface ───────────────────────────────────
+
+/**
+ * Runtime configuration for a Main Street game.
+ *
+ * Created from a `DifficultyPreset` at setup time and stored on the
+ * game state so that engine logic can read values without importing
+ * module-level constants.
+ */
+export interface GameConfig {
+  /** Human-readable difficulty name (for UI display). */
+  readonly difficultyName: DifficultyName;
+
+  // ── Economy ─────────────────────────────────────────────
+  /** Starting coin balance. */
+  readonly startingCoins: number;
+  /** Starting reputation. */
+  readonly startingReputation: number;
+
+  // ── Turn Structure ──────────────────────────────────────
+  /** Maximum number of turns before the game ends. */
+  readonly maxTurns: number;
+
+  // ── Scoring ─────────────────────────────────────────────
+  /** Score required for a win via score threshold. */
+  readonly winThreshold: number;
+  /** Multiplier applied to reputation in final score. */
+  readonly reputationScoreMultiplier: number;
+  /** Points awarded per completed challenge. */
+  readonly challengeBonusPoints: number;
+
+  // ── Synergy ─────────────────────────────────────────────
+  /** Coins earned per adjacent business sharing a synergy type. */
+  readonly synergyBonusPerNeighbor: number;
+
+  // ── Challenges ──────────────────────────────────────────
+  /** Number of challenges selected per run. */
+  readonly challengesPerRun: number;
+}
+
+// ── Preset Definitions ──────────────────────────────────────
+
+/**
+ * Easy preset: generous resources, more turns, lower win threshold.
+ * Designed for new players learning the mechanics.
+ */
+export const EASY_PRESET: Readonly<GameConfig> = {
+  difficultyName: 'Easy',
+  startingCoins: 12,
+  startingReputation: 5,
+  maxTurns: 25,
+  winThreshold: 120,
+  reputationScoreMultiplier: 5,
+  challengeBonusPoints: 15,
+  synergyBonusPerNeighbor: 2,
+  challengesPerRun: 2,
+};
+
+/**
+ * Medium preset: matches the original hard-coded constants exactly.
+ * This is the default and the baseline for balance.
+ */
+export const MEDIUM_PRESET: Readonly<GameConfig> = {
+  difficultyName: 'Medium',
+  startingCoins: 8,
+  startingReputation: 3,
+  maxTurns: 20,
+  winThreshold: 150,
+  reputationScoreMultiplier: 5,
+  challengeBonusPoints: 10,
+  synergyBonusPerNeighbor: 1,
+  challengesPerRun: 3,
+};
+
+/**
+ * Hard preset: tight resources, fewer turns, higher win threshold.
+ * Designed for experienced players seeking a challenge.
+ */
+export const HARD_PRESET: Readonly<GameConfig> = {
+  difficultyName: 'Hard',
+  startingCoins: 5,
+  startingReputation: 2,
+  maxTurns: 15,
+  winThreshold: 180,
+  reputationScoreMultiplier: 5,
+  challengeBonusPoints: 8,
+  synergyBonusPerNeighbor: 1,
+  challengesPerRun: 4,
+};
+
+// ── Preset Registry ─────────────────────────────────────────
+
+/** Map of all available presets by name. */
+export const DIFFICULTY_PRESETS: Readonly<Record<DifficultyName, Readonly<GameConfig>>> = {
+  Easy: EASY_PRESET,
+  Medium: MEDIUM_PRESET,
+  Hard: HARD_PRESET,
+};
+
+/**
+ * Returns the `GameConfig` for the given difficulty name.
+ * Defaults to Medium if the name is not recognized.
+ */
+export function getPreset(name: DifficultyName | undefined): Readonly<GameConfig> {
+  if (name && name in DIFFICULTY_PRESETS) {
+    return DIFFICULTY_PRESETS[name];
+  }
+  return MEDIUM_PRESET;
+}
+
+/** All available difficulty names in display order. */
+export const DIFFICULTY_NAMES: readonly DifficultyName[] = ['Easy', 'Medium', 'Hard'];

--- a/example-games/main-street/MainStreetEngine.ts
+++ b/example-games/main-street/MainStreetEngine.ts
@@ -18,12 +18,6 @@
 import type { MainStreetState, DayPhase } from './MainStreetState';
 import { PHASE_ORDER, addLog } from './MainStreetState';
 import type { EventCard, SynergyType } from './MainStreetCards';
-import {
-  MAX_TURNS,
-  WIN_THRESHOLD,
-  REPUTATION_SCORE_MULTIPLIER,
-  CHALLENGE_BONUS_POINTS,
-} from './MainStreetCards';
 import { applyIncome, type IncomeResult } from './MainStreetAdjacency';
 import {
   purchaseBusiness,
@@ -93,13 +87,13 @@ export interface TurnResult {
 
 /**
  * Computes the final score.
- * Formula: coins + (reputation * 5) + (challengesCompleted * 10)
+ * Formula: coins + (reputation * reputationScoreMultiplier) + (challengesCompleted * challengeBonusPoints)
  */
 export function computeScore(state: MainStreetState): number {
   return (
     state.resourceBank.coins +
-    state.resourceBank.reputation * REPUTATION_SCORE_MULTIPLIER +
-    state.challengesCompleted.length * CHALLENGE_BONUS_POINTS
+    state.resourceBank.reputation * state.config.reputationScoreMultiplier +
+    state.challengesCompleted.length * state.config.challengeBonusPoints
   );
 }
 
@@ -383,7 +377,7 @@ export function checkEndConditions(state: MainStreetState): boolean {
   }
 
   // Win: score threshold
-  if (state.finalScore >= WIN_THRESHOLD) {
+  if (state.finalScore >= state.config.winThreshold) {
     state.gameResult = 'win';
     state.endReason = 'score_threshold';
     addLog(state, `Victory: Score threshold reached (${state.finalScore} pts)`, 'gain');
@@ -391,12 +385,12 @@ export function checkEndConditions(state: MainStreetState): boolean {
   }
 
   // Turn limit reached
-  if (state.turn >= MAX_TURNS) {
+  if (state.turn >= state.config.maxTurns) {
     // Turn-limit victory: positive reputation and coins >= 0
     if (state.resourceBank.reputation > 0 && state.resourceBank.coins >= 0) {
       state.gameResult = 'win';
       state.endReason = 'turn_limit_victory';
-      addLog(state, `Victory: Survived ${MAX_TURNS} turns (${state.finalScore} pts)`, 'gain');
+      addLog(state, `Victory: Survived ${state.config.maxTurns} turns (${state.finalScore} pts)`, 'gain');
       return true;
     }
 

--- a/example-games/main-street/MainStreetState.ts
+++ b/example-games/main-street/MainStreetState.ts
@@ -18,8 +18,6 @@ import {
   createEventDeck,
   createUpgradeDeck,
   GRID_SIZE,
-  STARTING_COINS,
-  STARTING_REPUTATION,
   MARKET_BUSINESS_SLOTS,
   MARKET_INVESTMENT_UPGRADE_COUNT,
   MARKET_INVESTMENT_EVENT_COUNT,
@@ -28,9 +26,13 @@ import {
 import {
   type ActiveChallenge,
   CHALLENGE_TEMPLATES,
-  DEFAULT_CHALLENGES_PER_RUN,
   selectChallenges,
 } from './MainStreetChallenges';
+import {
+  type GameConfig,
+  type DifficultyName,
+  getPreset,
+} from './MainStreetDifficulty';
 
 // ── Activity Log ────────────────────────────────────────────
 
@@ -140,7 +142,9 @@ export type EndReason =
  * All game logic operates on and returns this state.
  */
 export interface MainStreetState {
-  /** Current turn number (1-based, max MAX_TURNS). */
+  /** Runtime configuration derived from the selected difficulty preset. */
+  config: GameConfig;
+  /** Current turn number (1-based, max config.maxTurns). */
   turn: number;
   /** Current phase within the turn. */
   phase: DayPhase;
@@ -184,6 +188,8 @@ export interface MainStreetState {
 export interface MainStreetSetupOptions {
   /** Seed string for deterministic RNG. If omitted, a random seed is generated. */
   seed?: string;
+  /** Difficulty preset name. Defaults to 'Medium' if omitted. */
+  difficulty?: DifficultyName;
 }
 
 // ── Seed Helpers ────────────────────────────────────────────
@@ -242,6 +248,9 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
   const numericSeed = seedToNumber(seed);
   const rng = createSeededRng(numericSeed);
 
+  // Resolve difficulty preset into runtime config
+  const config = getPreset(options.difficulty);
+
   // Create and shuffle decks
   const businessDeck = createBusinessDeck();
   const eventDeck = createEventDeck();
@@ -278,15 +287,16 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
     incidentQueue.push(eventDeck.splice(idx, 1)[0]);
   }
 
-  // Build initial state
+  // Build initial state -- use config values instead of hard-coded constants
   const state: MainStreetState = {
+    config,
     turn: 1,
     phase: 'DayStart',
     streetGrid: new Array<BusinessCard | null>(GRID_SIZE).fill(null),
     market,
     resourceBank: {
-      coins: STARTING_COINS,
-      reputation: STARTING_REPUTATION,
+      coins: config.startingCoins,
+      reputation: config.startingReputation,
     },
     decks: {
       business: businessDeck,
@@ -305,8 +315,8 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
     activityLog: [],
   };
 
-  // Select challenges for this run using seeded RNG
-  const selectedChallenges = selectChallenges(CHALLENGE_TEMPLATES, DEFAULT_CHALLENGES_PER_RUN, rng);
+  // Select challenges for this run using seeded RNG and config count
+  const selectedChallenges = selectChallenges(CHALLENGE_TEMPLATES, config.challengesPerRun, rng);
   state.activeChallenges = selectedChallenges.map(ch => ({
     challenge: ch,
     completed: false,

--- a/example-games/main-street/scenes/MainStreetScene.ts
+++ b/example-games/main-street/scenes/MainStreetScene.ts
@@ -14,10 +14,11 @@
 
 import type { MainStreetState } from '../MainStreetState';
 import { setupMainStreetGame } from '../MainStreetState';
+import type { DifficultyName } from '../MainStreetDifficulty';
+import { DIFFICULTY_NAMES } from '../MainStreetDifficulty';
 import type { BusinessCard, EventCard, UpgradeCard } from '../MainStreetCards';
 import {
   GRID_SIZE,
-  MAX_TURNS,
   synergyColor,
   cardLabel,
   MARKET_BUSINESS_SLOTS,
@@ -147,6 +148,9 @@ export class MainStreetScene extends CardGameScene {
   private state!: MainStreetState;
   private uiPhase: UIPhase = 'idle';
 
+  // Selected difficulty (persisted across replays)
+  private selectedDifficulty: DifficultyName = 'Medium';
+
   // Pending selection for placing a business
   private pendingBusinessCard: BusinessCard | null = null;
 
@@ -199,7 +203,10 @@ export class MainStreetScene extends CardGameScene {
     this.initSoundSystem([], {});
 
     // Game setup
-    this.state = setupMainStreetGame({ seed: 'main-street-demo' });
+    this.state = setupMainStreetGame({
+      seed: 'main-street-demo',
+      difficulty: this.selectedDifficulty,
+    });
 
     // UI scaffolding
     this.createHeader();
@@ -221,12 +228,12 @@ export class MainStreetScene extends CardGameScene {
       {
         heading: 'Challenges',
         body:
-          'Each run selects 3 random challenges for you to complete.\n' +
+          `Each run selects ${this.state.config.challengesPerRun} random challenges for you to complete.\n` +
           'Challenges have goals like earning coins, placing businesses,\n' +
           'or building synergy combos. Progress is checked at the end of\n' +
           'each turn -- once completed, a challenge stays completed.\n' +
-          'Each completed challenge adds 10 bonus points to your score.\n' +
-          'Complete all 3 challenges to win immediately!\n' +
+          `Each completed challenge adds ${this.state.config.challengeBonusPoints} bonus points to your score.\n` +
+          `Complete all ${this.state.config.challengesPerRun} challenges to win immediately!\n` +
           'Track your progress in the challenge panel at the bottom.',
       },
       {
@@ -250,9 +257,9 @@ export class MainStreetScene extends CardGameScene {
       {
         heading: 'Win / Loss',
         body:
-          `Reach ${150} points to win (coins + reputation*5 + challenges*10).\n` +
-          'Complete all 3 challenges for an instant win.\n' +
-          `Survive ${MAX_TURNS} turns with positive reputation for a turn-limit victory.\n` +
+          `Reach ${this.state.config.winThreshold} points to win (coins + reputation*${this.state.config.reputationScoreMultiplier} + challenges*${this.state.config.challengeBonusPoints}).\n` +
+          `Complete all ${this.state.config.challengesPerRun} challenges for an instant win.\n` +
+          `Survive ${this.state.config.maxTurns} turns with positive reputation for a turn-limit victory.\n` +
           'Bankruptcy (coins < 0) or reputation collapse (rep <= 0 after turn 1) loses.',
       },
     ];
@@ -336,7 +343,7 @@ export class MainStreetScene extends CardGameScene {
     this.uiPhase = 'market';
     this.refreshAll();
     this.instructionText.setText(
-      `Turn ${this.state.turn} / ${MAX_TURNS} -- Buy cards from the market or End Turn`,
+      `Turn ${this.state.turn} / ${this.state.config.maxTurns} -- Buy cards from the market or End Turn`,
     );
   }
 
@@ -395,7 +402,7 @@ export class MainStreetScene extends CardGameScene {
     this.hudContainer.add(strip);
 
     // Turn
-    const turnText = this.add.text(40, HUD_Y, `Turn ${this.state.turn}/${MAX_TURNS}`, {
+    const turnText = this.add.text(40, HUD_Y, `Turn ${this.state.turn}/${this.state.config.maxTurns}`, {
       fontSize: '16px', fontStyle: 'bold', color: '#ffdd88', fontFamily: FONT_FAMILY,
     }).setOrigin(0, 0.5);
     this.hudContainer.add(turnText);
@@ -405,6 +412,12 @@ export class MainStreetScene extends CardGameScene {
       fontSize: '14px', color: '#aa9977', fontFamily: FONT_FAMILY,
     }).setOrigin(0, 0.5);
     this.hudContainer.add(phaseText);
+
+    // Difficulty
+    const diffText = this.add.text(420, HUD_Y, `[${this.state.config.difficultyName}]`, {
+      fontSize: '13px', color: '#999977', fontFamily: FONT_FAMILY,
+    }).setOrigin(0, 0.5);
+    this.hudContainer.add(diffText);
 
     // Coins
     const coinText = this.add.text(GAME_W / 2 - 100, HUD_Y, `Coins: ${coins}`, {
@@ -1044,7 +1057,7 @@ export class MainStreetScene extends CardGameScene {
         this.uiPhase = 'market';
         this.refreshAll();
         this.instructionText.setText(
-          `Turn ${this.state.turn} / ${MAX_TURNS} -- Buy cards from the market or End Turn`,
+          `Turn ${this.state.turn} / ${this.state.config.maxTurns} -- Buy cards from the market or End Turn`,
         );
       });
       this.actionContainer.add(cancelBtn);
@@ -1299,7 +1312,7 @@ export class MainStreetScene extends CardGameScene {
     const challengeLineCount = activeChallenges.length;
     // Extra height: section header + one line per challenge
     const challengeExtraH = challengeLineCount > 0 ? 24 + challengeLineCount * 20 : 0;
-    const panelH = 320 + challengeExtraH;
+    const panelH = 360 + challengeExtraH; // extra 40px for difficulty selector
 
     // Overlay background
     const overlay = createOverlayBackground(
@@ -1330,10 +1343,11 @@ export class MainStreetScene extends CardGameScene {
     // Score breakdown
     const { coins, reputation } = this.state.resourceBank;
     const challenges = this.state.challengesCompleted.length;
+    const cfg = this.state.config;
     const lines = [
       `Coins: ${coins}`,
-      `Reputation: ${reputation} (x5 = ${reputation * 5})`,
-      `Challenges: ${challenges} (x10 = ${challenges * 10})`,
+      `Reputation: ${reputation} (x${cfg.reputationScoreMultiplier} = ${reputation * cfg.reputationScoreMultiplier})`,
+      `Challenges: ${challenges} (x${cfg.challengeBonusPoints} = ${challenges * cfg.challengeBonusPoints})`,
       `Final Score: ${result.finalScore}`,
     ];
     const breakdownY = panelTop + 110;
@@ -1367,6 +1381,27 @@ export class MainStreetScene extends CardGameScene {
         challengeBottomY += 20;
       }
     }
+
+    // Difficulty selector
+    const diffY = panelTop + panelH - 80;
+    const diffLabel = this.add.text(
+      GAME_W / 2 - 80, diffY,
+      `Difficulty: ${this.selectedDifficulty}`,
+      { fontSize: '14px', color: '#ccbbaa', fontFamily: FONT_FAMILY },
+    ).setOrigin(0, 0.5).setDepth(101);
+    this.overlayObjects.push(diffLabel);
+
+    const cycleBtn = this.add.text(
+      GAME_W / 2 + 90, diffY,
+      '[ Change ]',
+      { fontSize: '14px', color: '#ffdd88', fontFamily: FONT_FAMILY },
+    ).setOrigin(0, 0.5).setDepth(101).setInteractive({ useHandCursor: true });
+    cycleBtn.on('pointerdown', () => {
+      const idx = DIFFICULTY_NAMES.indexOf(this.selectedDifficulty);
+      this.selectedDifficulty = DIFFICULTY_NAMES[(idx + 1) % DIFFICULTY_NAMES.length];
+      diffLabel.setText(`Difficulty: ${this.selectedDifficulty}`);
+    });
+    this.overlayObjects.push(cycleBtn);
 
     // Buttons (positioned relative to panel bottom)
     const btnY = panelTop + panelH - 40;

--- a/tests/main-street/difficulty-presets.test.ts
+++ b/tests/main-street/difficulty-presets.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Main Street: Difficulty Presets Tests
+ *
+ * Tests for the DifficultyPresets module, preset application via
+ * setupMainStreetGame, and integration with engine scoring and
+ * win/loss conditions.
+ *
+ * Work items: CG-0MMJ8S87N06Q5GP1, CG-0MMJ9O4K403TOIWA
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  type GameConfig,
+  type DifficultyName,
+  EASY_PRESET,
+  MEDIUM_PRESET,
+  HARD_PRESET,
+  DIFFICULTY_PRESETS,
+  DIFFICULTY_NAMES,
+  getPreset,
+} from '../../example-games/main-street/MainStreetDifficulty';
+
+import {
+  setupMainStreetGame,
+  type MainStreetState,
+} from '../../example-games/main-street/MainStreetState';
+
+import {
+  STARTING_COINS,
+  STARTING_REPUTATION,
+  MAX_TURNS,
+  WIN_THRESHOLD,
+  SYNERGY_BONUS_PER_NEIGHBOR,
+  REPUTATION_SCORE_MULTIPLIER,
+  CHALLENGE_BONUS_POINTS,
+} from '../../example-games/main-street/MainStreetCards';
+
+import { DEFAULT_CHALLENGES_PER_RUN } from '../../example-games/main-street/MainStreetChallenges';
+
+import {
+  computeScore,
+  checkEndConditions,
+} from '../../example-games/main-street/MainStreetEngine';
+
+import {
+  computeSynergyBonus,
+} from '../../example-games/main-street/MainStreetAdjacency';
+
+import type { BusinessCard } from '../../example-games/main-street/MainStreetCards';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function createTestState(
+  seed: string = 'test-diff',
+  difficulty?: DifficultyName,
+): MainStreetState {
+  return setupMainStreetGame({ seed, difficulty });
+}
+
+function makeTestBusiness(overrides: Partial<BusinessCard> = {}): BusinessCard {
+  return {
+    family: 'business',
+    id: 'test-biz',
+    name: 'Test Business',
+    cost: 3,
+    baseIncome: 2,
+    synergyTypes: ['Food'],
+    maxLevel: 1,
+    description: 'Test',
+    level: 0,
+    incomeBonus: 0,
+    synergyRangeBonus: 0,
+    ...overrides,
+  };
+}
+
+// ── Preset Definition Tests ─────────────────────────────────
+
+describe('DifficultyPresets Module', () => {
+  describe('preset definitions', () => {
+    it('should define exactly 3 presets', () => {
+      expect(DIFFICULTY_NAMES).toHaveLength(3);
+      expect(Object.keys(DIFFICULTY_PRESETS)).toHaveLength(3);
+    });
+
+    it('should have Easy, Medium, and Hard presets', () => {
+      expect(DIFFICULTY_NAMES).toEqual(['Easy', 'Medium', 'Hard']);
+      expect(DIFFICULTY_PRESETS.Easy).toBeDefined();
+      expect(DIFFICULTY_PRESETS.Medium).toBeDefined();
+      expect(DIFFICULTY_PRESETS.Hard).toBeDefined();
+    });
+
+    it('should have correct difficulty names on each preset', () => {
+      expect(EASY_PRESET.difficultyName).toBe('Easy');
+      expect(MEDIUM_PRESET.difficultyName).toBe('Medium');
+      expect(HARD_PRESET.difficultyName).toBe('Hard');
+    });
+
+    it('should have all required config fields on every preset', () => {
+      const requiredKeys: (keyof GameConfig)[] = [
+        'difficultyName',
+        'startingCoins',
+        'startingReputation',
+        'maxTurns',
+        'winThreshold',
+        'reputationScoreMultiplier',
+        'challengeBonusPoints',
+        'synergyBonusPerNeighbor',
+        'challengesPerRun',
+      ];
+      for (const preset of [EASY_PRESET, MEDIUM_PRESET, HARD_PRESET]) {
+        for (const key of requiredKeys) {
+          expect(preset).toHaveProperty(key);
+        }
+      }
+    });
+
+    it('should have positive numeric values for all parameter fields', () => {
+      const numericKeys: (keyof GameConfig)[] = [
+        'startingCoins',
+        'startingReputation',
+        'maxTurns',
+        'winThreshold',
+        'reputationScoreMultiplier',
+        'challengeBonusPoints',
+        'synergyBonusPerNeighbor',
+        'challengesPerRun',
+      ];
+      for (const preset of [EASY_PRESET, MEDIUM_PRESET, HARD_PRESET]) {
+        for (const key of numericKeys) {
+          const value = preset[key];
+          expect(typeof value).toBe('number');
+          expect(value as number).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe('Medium preset matches original constants', () => {
+    it('should match STARTING_COINS', () => {
+      expect(MEDIUM_PRESET.startingCoins).toBe(STARTING_COINS);
+    });
+
+    it('should match STARTING_REPUTATION', () => {
+      expect(MEDIUM_PRESET.startingReputation).toBe(STARTING_REPUTATION);
+    });
+
+    it('should match MAX_TURNS', () => {
+      expect(MEDIUM_PRESET.maxTurns).toBe(MAX_TURNS);
+    });
+
+    it('should match WIN_THRESHOLD', () => {
+      expect(MEDIUM_PRESET.winThreshold).toBe(WIN_THRESHOLD);
+    });
+
+    it('should match SYNERGY_BONUS_PER_NEIGHBOR', () => {
+      expect(MEDIUM_PRESET.synergyBonusPerNeighbor).toBe(SYNERGY_BONUS_PER_NEIGHBOR);
+    });
+
+    it('should match REPUTATION_SCORE_MULTIPLIER', () => {
+      expect(MEDIUM_PRESET.reputationScoreMultiplier).toBe(REPUTATION_SCORE_MULTIPLIER);
+    });
+
+    it('should match CHALLENGE_BONUS_POINTS', () => {
+      expect(MEDIUM_PRESET.challengeBonusPoints).toBe(CHALLENGE_BONUS_POINTS);
+    });
+
+    it('should match DEFAULT_CHALLENGES_PER_RUN', () => {
+      expect(MEDIUM_PRESET.challengesPerRun).toBe(DEFAULT_CHALLENGES_PER_RUN);
+    });
+  });
+
+  describe('Easy preset is more generous than Medium', () => {
+    it('should have more starting coins', () => {
+      expect(EASY_PRESET.startingCoins).toBeGreaterThan(MEDIUM_PRESET.startingCoins);
+    });
+
+    it('should have more starting reputation', () => {
+      expect(EASY_PRESET.startingReputation).toBeGreaterThan(MEDIUM_PRESET.startingReputation);
+    });
+
+    it('should have more turns', () => {
+      expect(EASY_PRESET.maxTurns).toBeGreaterThan(MEDIUM_PRESET.maxTurns);
+    });
+
+    it('should have lower win threshold', () => {
+      expect(EASY_PRESET.winThreshold).toBeLessThan(MEDIUM_PRESET.winThreshold);
+    });
+
+    it('should have higher synergy bonus per neighbor', () => {
+      expect(EASY_PRESET.synergyBonusPerNeighbor).toBeGreaterThanOrEqual(
+        MEDIUM_PRESET.synergyBonusPerNeighbor,
+      );
+    });
+
+    it('should have fewer challenges per run', () => {
+      expect(EASY_PRESET.challengesPerRun).toBeLessThan(MEDIUM_PRESET.challengesPerRun);
+    });
+  });
+
+  describe('Hard preset is more challenging than Medium', () => {
+    it('should have fewer starting coins', () => {
+      expect(HARD_PRESET.startingCoins).toBeLessThan(MEDIUM_PRESET.startingCoins);
+    });
+
+    it('should have fewer starting reputation', () => {
+      expect(HARD_PRESET.startingReputation).toBeLessThan(MEDIUM_PRESET.startingReputation);
+    });
+
+    it('should have fewer turns', () => {
+      expect(HARD_PRESET.maxTurns).toBeLessThan(MEDIUM_PRESET.maxTurns);
+    });
+
+    it('should have higher win threshold', () => {
+      expect(HARD_PRESET.winThreshold).toBeGreaterThan(MEDIUM_PRESET.winThreshold);
+    });
+
+    it('should have more challenges per run', () => {
+      expect(HARD_PRESET.challengesPerRun).toBeGreaterThan(MEDIUM_PRESET.challengesPerRun);
+    });
+  });
+
+  describe('getPreset()', () => {
+    it('should return the correct preset for each difficulty name', () => {
+      expect(getPreset('Easy')).toBe(EASY_PRESET);
+      expect(getPreset('Medium')).toBe(MEDIUM_PRESET);
+      expect(getPreset('Hard')).toBe(HARD_PRESET);
+    });
+
+    it('should default to Medium when undefined', () => {
+      expect(getPreset(undefined)).toBe(MEDIUM_PRESET);
+    });
+  });
+});
+
+// ── Setup Integration Tests ─────────────────────────────────
+
+describe('setupMainStreetGame with difficulty', () => {
+  describe('default (no difficulty specified)', () => {
+    it('should use Medium config', () => {
+      const state = createTestState('default-test');
+      expect(state.config).toBe(MEDIUM_PRESET);
+      expect(state.config.difficultyName).toBe('Medium');
+    });
+
+    it('should have Medium starting coins', () => {
+      const state = createTestState('default-test');
+      expect(state.resourceBank.coins).toBe(MEDIUM_PRESET.startingCoins);
+    });
+
+    it('should have Medium starting reputation', () => {
+      const state = createTestState('default-test');
+      expect(state.resourceBank.reputation).toBe(MEDIUM_PRESET.startingReputation);
+    });
+
+    it('should select Medium challenge count', () => {
+      const state = createTestState('default-test');
+      expect(state.activeChallenges).toHaveLength(MEDIUM_PRESET.challengesPerRun);
+    });
+  });
+
+  describe('Easy difficulty', () => {
+    it('should use Easy config', () => {
+      const state = createTestState('easy-test', 'Easy');
+      expect(state.config).toBe(EASY_PRESET);
+    });
+
+    it('should have Easy starting coins', () => {
+      const state = createTestState('easy-test', 'Easy');
+      expect(state.resourceBank.coins).toBe(EASY_PRESET.startingCoins);
+    });
+
+    it('should have Easy starting reputation', () => {
+      const state = createTestState('easy-test', 'Easy');
+      expect(state.resourceBank.reputation).toBe(EASY_PRESET.startingReputation);
+    });
+
+    it('should select Easy challenge count', () => {
+      const state = createTestState('easy-test', 'Easy');
+      expect(state.activeChallenges).toHaveLength(EASY_PRESET.challengesPerRun);
+    });
+  });
+
+  describe('Hard difficulty', () => {
+    it('should use Hard config', () => {
+      const state = createTestState('hard-test', 'Hard');
+      expect(state.config).toBe(HARD_PRESET);
+    });
+
+    it('should have Hard starting coins', () => {
+      const state = createTestState('hard-test', 'Hard');
+      expect(state.resourceBank.coins).toBe(HARD_PRESET.startingCoins);
+    });
+
+    it('should have Hard starting reputation', () => {
+      const state = createTestState('hard-test', 'Hard');
+      expect(state.resourceBank.reputation).toBe(HARD_PRESET.startingReputation);
+    });
+
+    it('should select Hard challenge count', () => {
+      const state = createTestState('hard-test', 'Hard');
+      expect(state.activeChallenges).toHaveLength(HARD_PRESET.challengesPerRun);
+    });
+  });
+
+  describe('seed determinism with difficulty', () => {
+    it('should produce identical states for the same seed and difficulty', () => {
+      const a = createTestState('determ-1', 'Hard');
+      const b = createTestState('determ-1', 'Hard');
+      expect(a.resourceBank.coins).toBe(b.resourceBank.coins);
+      expect(a.resourceBank.reputation).toBe(b.resourceBank.reputation);
+      expect(a.activeChallenges.map(c => c.challenge.id))
+        .toEqual(b.activeChallenges.map(c => c.challenge.id));
+    });
+
+    it('should produce different challenge selections for different seeds', () => {
+      // With enough seeds, at least one pair should differ
+      const seeds = ['seed-a', 'seed-b', 'seed-c', 'seed-d', 'seed-e'];
+      const selections = seeds.map(s =>
+        createTestState(s, 'Medium').activeChallenges.map(c => c.challenge.id).sort().join(','),
+      );
+      const unique = new Set(selections);
+      expect(unique.size).toBeGreaterThan(1);
+    });
+  });
+});
+
+// ── Engine Integration Tests ────────────────────────────────
+
+describe('Engine uses config values', () => {
+  describe('computeScore', () => {
+    it('should use config.reputationScoreMultiplier for Easy', () => {
+      const state = createTestState('score-easy', 'Easy');
+      state.resourceBank.coins = 10;
+      state.resourceBank.reputation = 4;
+      state.challengesCompleted = ['ch-1'];
+      const expected =
+        10 +
+        4 * EASY_PRESET.reputationScoreMultiplier +
+        1 * EASY_PRESET.challengeBonusPoints;
+      expect(computeScore(state)).toBe(expected);
+    });
+
+    it('should use config.challengeBonusPoints for Hard', () => {
+      const state = createTestState('score-hard', 'Hard');
+      state.resourceBank.coins = 5;
+      state.resourceBank.reputation = 2;
+      state.challengesCompleted = ['ch-1', 'ch-2'];
+      const expected =
+        5 +
+        2 * HARD_PRESET.reputationScoreMultiplier +
+        2 * HARD_PRESET.challengeBonusPoints;
+      expect(computeScore(state)).toBe(expected);
+    });
+  });
+
+  describe('checkEndConditions uses config.winThreshold', () => {
+    it('should not win below Easy winThreshold', () => {
+      const state = createTestState('threshold-easy', 'Easy');
+      state.phase = 'EndCheck';
+      state.resourceBank.coins = EASY_PRESET.winThreshold - 50;
+      state.resourceBank.reputation = 1;
+      state.challengesCompleted = [];
+      state.activeChallenges = [];
+      const ended = checkEndConditions(state);
+      if (ended) {
+        // Only end if turn limit
+        expect(state.endReason).not.toBe('score_threshold');
+      }
+    });
+
+    it('should win when score meets Easy winThreshold', () => {
+      const state = createTestState('threshold-easy-win', 'Easy');
+      state.phase = 'EndCheck';
+      state.resourceBank.coins = EASY_PRESET.winThreshold;
+      state.resourceBank.reputation = 1;
+      state.challengesCompleted = [];
+      state.activeChallenges = [];
+      const ended = checkEndConditions(state);
+      expect(ended).toBe(true);
+      expect(state.gameResult).toBe('win');
+      expect(state.endReason).toBe('score_threshold');
+    });
+
+    it('should require higher score for Hard winThreshold', () => {
+      const state = createTestState('threshold-hard', 'Hard');
+      state.phase = 'EndCheck';
+      // A score that would win on Easy but not on Hard
+      state.resourceBank.coins = EASY_PRESET.winThreshold;
+      state.resourceBank.reputation = 1;
+      state.challengesCompleted = [];
+      state.activeChallenges = [];
+      checkEndConditions(state);
+      // The score is EASY_PRESET.winThreshold + 1*5 = 125
+      // That's below Hard's 180 threshold
+      if (state.turn < HARD_PRESET.maxTurns) {
+        expect(state.endReason).not.toBe('score_threshold');
+      }
+    });
+  });
+
+  describe('checkEndConditions uses config.maxTurns', () => {
+    it('should not end at Easy maxTurns - 1', () => {
+      const state = createTestState('turns-easy', 'Easy');
+      state.phase = 'EndCheck';
+      state.turn = EASY_PRESET.maxTurns - 1;
+      state.resourceBank.coins = 5;
+      state.resourceBank.reputation = 1;
+      state.activeChallenges = [];
+      const ended = checkEndConditions(state);
+      // Score is 5 + 5 = 10, below threshold; turn not maxed
+      expect(ended).toBe(false);
+    });
+
+    it('should end at Easy maxTurns with positive rep as turn_limit_victory', () => {
+      const state = createTestState('turns-easy-end', 'Easy');
+      state.phase = 'EndCheck';
+      state.turn = EASY_PRESET.maxTurns;
+      state.resourceBank.coins = 5;
+      state.resourceBank.reputation = 1;
+      state.activeChallenges = [];
+      const ended = checkEndConditions(state);
+      expect(ended).toBe(true);
+      expect(state.endReason).toBe('turn_limit_victory');
+    });
+
+    it('should end at Hard maxTurns (15) not Medium maxTurns (20)', () => {
+      const state = createTestState('turns-hard', 'Hard');
+      state.phase = 'EndCheck';
+      state.turn = HARD_PRESET.maxTurns; // 15
+      state.resourceBank.coins = 5;
+      state.resourceBank.reputation = 1;
+      state.activeChallenges = [];
+      const ended = checkEndConditions(state);
+      expect(ended).toBe(true);
+      // Turn 15 is maxTurns for Hard
+    });
+  });
+});
+
+// ── Adjacency Integration Tests ─────────────────────────────
+
+describe('Adjacency uses config.synergyBonusPerNeighbor', () => {
+  it('should compute bonus of 1 per neighbor with SYNERGY_BONUS_PER_NEIGHBOR=1 (default)', () => {
+    const grid: (BusinessCard | null)[] = new Array(10).fill(null);
+    grid[0] = makeTestBusiness({ id: 'a', synergyTypes: ['Food'] });
+    grid[1] = makeTestBusiness({ id: 'b', synergyTypes: ['Food'] });
+    // Default bonus = 1
+    expect(computeSynergyBonus(grid, 0)).toBe(1);
+    expect(computeSynergyBonus(grid, 1)).toBe(1);
+  });
+
+  it('should compute bonus of 2 per neighbor when bonusPerNeighbor=2', () => {
+    const grid: (BusinessCard | null)[] = new Array(10).fill(null);
+    grid[0] = makeTestBusiness({ id: 'a', synergyTypes: ['Food'] });
+    grid[1] = makeTestBusiness({ id: 'b', synergyTypes: ['Food'] });
+    // Easy bonus = 2
+    expect(computeSynergyBonus(grid, 0, 2)).toBe(2);
+    expect(computeSynergyBonus(grid, 1, 2)).toBe(2);
+  });
+
+  it('should scale correctly with multiple neighbors', () => {
+    const grid: (BusinessCard | null)[] = new Array(10).fill(null);
+    grid[3] = makeTestBusiness({ id: 'a', synergyTypes: ['Food'] });
+    grid[4] = makeTestBusiness({ id: 'b', synergyTypes: ['Food'] });
+    grid[5] = makeTestBusiness({ id: 'c', synergyTypes: ['Food'] });
+    // Middle business has 2 neighbors with matching synergy
+    expect(computeSynergyBonus(grid, 4, 1)).toBe(2); // 2 neighbors * 1
+    expect(computeSynergyBonus(grid, 4, 2)).toBe(4); // 2 neighbors * 2
+  });
+});


### PR DESCRIPTION
## Summary
- Add named difficulty presets (Easy/Medium/Hard) that parameterize starting coins, starting reputation, max turns, win threshold, reputation score multiplier, challenge bonus points, synergy bonus per neighbor, and challenges per run
- Medium preset exactly matches original hard-coded constants for full backward compatibility
- All 2004 existing unit tests pass unchanged; 51 new tests added

## Changes
- **New**: `MainStreetDifficulty.ts` -- `GameConfig` interface, 3 preset definitions, `getPreset()`, `DIFFICULTY_NAMES`/`DIFFICULTY_PRESETS`
- **Modified**: `MainStreetState.ts` -- Added `config: GameConfig` to state; `setupMainStreetGame` resolves preset from `difficulty` option
- **Modified**: `MainStreetEngine.ts` -- `computeScore` and `checkEndConditions` read from `state.config` instead of module constants
- **Modified**: `MainStreetAdjacency.ts` -- Added `bonusPerNeighbor` parameter; `applyIncome` uses `state.config.synergyBonusPerNeighbor`
- **Modified**: `MainStreetScene.ts` -- Difficulty selector on game-over overlay, HUD indicator, dynamic help text
- **New**: `tests/main-street/difficulty-presets.test.ts` -- 51 tests covering presets, constants matching, setup integration, engine scoring, adjacency

## Work Items
- CG-0MMJ8S87N06Q5GP1: Difficulty Presets (Easy/Medium/Hard)
- CG-0MMJ9O4K403TOIWA: Tests: Difficulty Presets (Easy/Medium/Hard)

## Quality Gates
- `npm test -- --run`: 78 files, 2004 passed, 5 skipped
- `npm run build`: TypeScript + Vite build succeeds