### PR TITLE
CG-0MMJ8S90S1P2HW74: add versioned save/load infrastructure

### DIFF
--- a/example-games/main-street/MainStreetSaveLoad.ts
+++ b/example-games/main-street/MainStreetSaveLoad.ts
@@ -1,0 +1,94 @@
+import {
+  SaveLoadStore,
+  type SaveSerializer,
+} from '../../src/core-engine';
+import {
+  type MainStreetCampaignProgress,
+  type MainStreetSerializedState,
+  type MainStreetState,
+  serializeMainStreetState,
+  deserializeMainStreetState,
+} from './MainStreetState';
+
+export const MAIN_STREET_SAVE_SCHEMA_VERSION = 1;
+export const MAIN_STREET_CAMPAIGN_SCHEMA_VERSION = 1;
+export const MAIN_STREET_GAME_TYPE = 'main-street';
+export const MAIN_STREET_RUN_SLOT = 'turn-start';
+export const MAIN_STREET_CAMPAIGN_SLOT = 'campaign-default';
+
+export const mainStreetStateSerializer: SaveSerializer<
+  MainStreetState,
+  MainStreetSerializedState
+> = {
+  schemaVersion: MAIN_STREET_SAVE_SCHEMA_VERSION,
+  serialize: serializeMainStreetState,
+  deserialize: deserializeMainStreetState,
+};
+
+export const mainStreetCampaignSerializer: SaveSerializer<
+  MainStreetCampaignProgress,
+  MainStreetCampaignProgress
+> = {
+  schemaVersion: MAIN_STREET_CAMPAIGN_SCHEMA_VERSION,
+  serialize: (state) => structuredClone(state),
+  deserialize: (data) => structuredClone(data),
+};
+
+export function createDefaultCampaignProgress(): MainStreetCampaignProgress {
+  return {
+    unlockedTiers: ['tier-1'],
+    persistentReputation: 0,
+    highestScore: 0,
+    totalRuns: 0,
+    totalWins: 0,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+}
+
+export async function saveTurnStartCheckpoint(
+  store: SaveLoadStore,
+  state: MainStreetState,
+  slotId: string = MAIN_STREET_RUN_SLOT,
+): Promise<void> {
+  await store.saveRunCheckpoint(
+    MAIN_STREET_GAME_TYPE,
+    slotId,
+    mainStreetStateSerializer,
+    state,
+  );
+}
+
+export async function loadTurnStartCheckpoint(
+  store: SaveLoadStore,
+  slotId: string = MAIN_STREET_RUN_SLOT,
+): Promise<MainStreetState | null> {
+  return store.loadRunCheckpoint(
+    MAIN_STREET_GAME_TYPE,
+    slotId,
+    mainStreetStateSerializer,
+  );
+}
+
+export async function saveCampaignProgress(
+  store: SaveLoadStore,
+  progress: MainStreetCampaignProgress,
+  slotId: string = MAIN_STREET_CAMPAIGN_SLOT,
+): Promise<void> {
+  await store.saveCampaignProgress(
+    MAIN_STREET_GAME_TYPE,
+    slotId,
+    mainStreetCampaignSerializer,
+    progress,
+  );
+}
+
+export async function loadCampaignProgress(
+  store: SaveLoadStore,
+  slotId: string = MAIN_STREET_CAMPAIGN_SLOT,
+): Promise<MainStreetCampaignProgress | null> {
+  return store.loadCampaignProgress(
+    MAIN_STREET_GAME_TYPE,
+    slotId,
+    mainStreetCampaignSerializer,
+  );
+}

--- a/example-games/main-street/MainStreetState.ts
+++ b/example-games/main-street/MainStreetState.ts
@@ -176,10 +176,51 @@ export interface MainStreetState {
   finalScore: number;
   /** The seed string used for this game. */
   seed: string;
+  /** Numeric seed derived from the seed string (used for restore). */
+  numericSeed: number;
+  /** Number of RNG draws consumed so far (used for deterministic restore). */
+  rngCalls: number;
   /** The RNG function for this game (seeded, deterministic). */
   rng: () => number;
   /** Chronological log of game activities for the UI activity log panel. */
   activityLog: LogEntry[];
+}
+
+export interface MainStreetSerializedState {
+  config: GameConfig;
+  turn: number;
+  phase: DayPhase;
+  streetGrid: (BusinessCard | null)[];
+  market: MarketState;
+  resourceBank: ResourceBank;
+  decks: {
+    business: BusinessCard[];
+    event: EventCard[];
+    upgrade: UpgradeCard[];
+  };
+  challengesCompleted: string[];
+  activeChallenges: {
+    challengeId: string;
+    completed: boolean;
+  }[];
+  heldEvent: EventCard | null;
+  incidentQueue: EventCard[];
+  gameResult: GameResult;
+  endReason: EndReason;
+  finalScore: number;
+  seed: string;
+  numericSeed: number;
+  rngCalls: number;
+  activityLog: LogEntry[];
+}
+
+export interface MainStreetCampaignProgress {
+  unlockedTiers: string[];
+  persistentReputation: number;
+  highestScore: number;
+  totalRuns: number;
+  totalWins: number;
+  lastUpdatedAt: string;
 }
 
 // ── Setup Options ───────────────────────────────────────────
@@ -246,7 +287,16 @@ function fillMarketSlots<T>(deck: T[], count: number): T[] {
 export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainStreetState {
   const seed = options.seed ?? generateSeedString();
   const numericSeed = seedToNumber(seed);
-  const rng = createSeededRng(numericSeed);
+  const baseRng = createSeededRng(numericSeed);
+  let rngCalls = 0;
+  let state!: MainStreetState;
+  const rng = (): number => {
+    rngCalls += 1;
+    if (state) {
+      state.rngCalls = rngCalls;
+    }
+    return baseRng();
+  };
 
   // Resolve difficulty preset into runtime config
   const config = getPreset(options.difficulty);
@@ -288,7 +338,7 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
   }
 
   // Build initial state -- use config values instead of hard-coded constants
-  const state: MainStreetState = {
+  state = {
     config,
     turn: 1,
     phase: 'DayStart',
@@ -311,6 +361,8 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
     endReason: null,
     finalScore: 0,
     seed,
+    numericSeed,
+    rngCalls,
     rng,
     activityLog: [],
   };
@@ -321,6 +373,86 @@ export function setupMainStreetGame(options: MainStreetSetupOptions = {}): MainS
     challenge: ch,
     completed: false,
   }));
+
+  return state;
+}
+
+/**
+ * Serializes Main Street runtime state into a JSON-safe checkpoint shape.
+ */
+export function serializeMainStreetState(state: MainStreetState): MainStreetSerializedState {
+  return {
+    config: structuredClone(state.config),
+    turn: state.turn,
+    phase: state.phase,
+    streetGrid: structuredClone(state.streetGrid),
+    market: structuredClone(state.market),
+    resourceBank: structuredClone(state.resourceBank),
+    decks: structuredClone(state.decks),
+    challengesCompleted: [...state.challengesCompleted],
+    activeChallenges: state.activeChallenges.map((ac) => ({
+      challengeId: ac.challenge.id,
+      completed: ac.completed,
+    })),
+    heldEvent: structuredClone(state.heldEvent),
+    incidentQueue: structuredClone(state.incidentQueue),
+    gameResult: state.gameResult,
+    endReason: state.endReason,
+    finalScore: state.finalScore,
+    seed: state.seed,
+    numericSeed: state.numericSeed,
+    rngCalls: state.rngCalls,
+    activityLog: structuredClone(state.activityLog),
+  };
+}
+
+/**
+ * Rehydrates runtime state from a serialized checkpoint.
+ */
+export function deserializeMainStreetState(saved: MainStreetSerializedState): MainStreetState {
+  const baseRng = createSeededRng(saved.numericSeed);
+  for (let i = 0; i < saved.rngCalls; i++) {
+    baseRng();
+  }
+
+  let rngCalls = saved.rngCalls;
+  let state!: MainStreetState;
+  const rng = (): number => {
+    rngCalls += 1;
+    state.rngCalls = rngCalls;
+    return baseRng();
+  };
+
+  state = {
+    config: structuredClone(saved.config),
+    turn: saved.turn,
+    phase: saved.phase,
+    streetGrid: structuredClone(saved.streetGrid),
+    market: structuredClone(saved.market),
+    resourceBank: structuredClone(saved.resourceBank),
+    decks: structuredClone(saved.decks),
+    challengesCompleted: [...saved.challengesCompleted],
+    activeChallenges: saved.activeChallenges.map((ac) => {
+      const challenge = CHALLENGE_TEMPLATES.find((tpl) => tpl.id === ac.challengeId);
+      if (!challenge) {
+        throw new Error(`Unknown challenge id in save: ${ac.challengeId}`);
+      }
+      return {
+        challenge,
+        completed: ac.completed,
+      };
+    }),
+    heldEvent: structuredClone(saved.heldEvent),
+    incidentQueue: structuredClone(saved.incidentQueue),
+    gameResult: saved.gameResult,
+    endReason: saved.endReason,
+    finalScore: saved.finalScore,
+    seed: saved.seed,
+    numericSeed: saved.numericSeed,
+    rngCalls: saved.rngCalls,
+    rng,
+    activityLog: structuredClone(saved.activityLog),
+  };
 
   return state;
 }

--- a/src/core-engine/SaveLoad.ts
+++ b/src/core-engine/SaveLoad.ts
@@ -1,0 +1,468 @@
+/**
+ * Save/Load infrastructure for versioned game-state persistence.
+ *
+ * Persists versioned payloads to IndexedDB (preferred) with a localStorage
+ * fallback. Supports separate save domains for run checkpoints and campaign
+ * progression data.
+ */
+
+export type SaveDomain = 'run-checkpoint' | 'campaign';
+
+export interface StoredSave<T = unknown> {
+  id: string;
+  slotId: string;
+  gameType: string;
+  domain: SaveDomain;
+  schemaVersion: number;
+  savedAt: string;
+  seq: number;
+  payload: T;
+}
+
+export interface SaveLoadStoreOptions {
+  dbName?: string;
+  storeName?: string;
+  localStoragePrefix?: string;
+}
+
+export interface VersionedPayload<T> {
+  schemaVersion: number;
+  data: T;
+}
+
+export interface SaveSerializer<TState, TSerialized> {
+  readonly schemaVersion: number;
+  serialize(state: TState): TSerialized;
+  deserialize(data: TSerialized): TState;
+}
+
+const DEFAULT_DB_NAME = 'save-load-store';
+const DEFAULT_STORE_NAME = 'saves';
+const DEFAULT_LS_PREFIX = 'tce-saves';
+
+interface StorageBackend {
+  save(entry: StoredSave): Promise<void>;
+  list(domain: SaveDomain, gameType: string): Promise<StoredSave[]>;
+  getBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<StoredSave | null>;
+  removeBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<void>;
+  clear(domain?: SaveDomain, gameType?: string): Promise<void>;
+  readonly name: string;
+}
+
+class IndexedDBBackend implements StorageBackend {
+  readonly name = 'IndexedDB';
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  constructor(
+    private readonly dbName: string,
+    private readonly storeName: string,
+  ) {}
+
+  private openDB(): Promise<IDBDatabase> {
+    if (this.dbPromise) return this.dbPromise;
+
+    this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(this.dbName, 1);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          const store = db.createObjectStore(this.storeName, { keyPath: 'id' });
+          store.createIndex('domain_gameType', ['domain', 'gameType'], { unique: false });
+          store.createIndex('domain_gameType_slot', ['domain', 'gameType', 'slotId'], { unique: true });
+          store.createIndex('savedAt', 'savedAt', { unique: false });
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => {
+        this.dbPromise = null;
+        reject(request.error);
+      };
+    });
+
+    return this.dbPromise;
+  }
+
+  async save(entry: StoredSave): Promise<void> {
+    const db = await this.openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readwrite');
+      const store = tx.objectStore(this.storeName);
+      const index = store.index('domain_gameType_slot');
+      const key = [entry.domain, entry.gameType, entry.slotId] as [SaveDomain, string, string];
+      const existingReq = index.getKey(key);
+
+      existingReq.onsuccess = () => {
+        const existingKey = existingReq.result as string | undefined;
+        if (existingKey && existingKey !== entry.id) {
+          store.delete(existingKey);
+        }
+        store.put(entry);
+      };
+
+      existingReq.onerror = () => reject(existingReq.error);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async list(domain: SaveDomain, gameType: string): Promise<StoredSave[]> {
+    const db = await this.openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readonly');
+      const index = tx.objectStore(this.storeName).index('domain_gameType');
+      const request = index.getAll([domain, gameType]);
+      request.onsuccess = () => {
+        const results = request.result as StoredSave[];
+        results.sort((a, b) => (b.seq ?? 0) - (a.seq ?? 0));
+        resolve(results);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async getBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<StoredSave | null> {
+    const db = await this.openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readonly');
+      const index = tx.objectStore(this.storeName).index('domain_gameType_slot');
+      const request = index.get([domain, gameType, slotId]);
+      request.onsuccess = () => resolve(request.result ?? null);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async removeBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<void> {
+    const db = await this.openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readwrite');
+      const store = tx.objectStore(this.storeName);
+      const index = store.index('domain_gameType_slot');
+      const keyReq = index.getKey([domain, gameType, slotId]);
+
+      keyReq.onsuccess = () => {
+        const id = keyReq.result as string | undefined;
+        if (id) store.delete(id);
+      };
+      keyReq.onerror = () => reject(keyReq.error);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async clear(domain?: SaveDomain, gameType?: string): Promise<void> {
+    if (!domain || !gameType) {
+      const db = await this.openDB();
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(this.storeName, 'readwrite');
+        tx.objectStore(this.storeName).clear();
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+    }
+
+    const entries = await this.list(domain, gameType);
+    const db = await this.openDB();
+    const tx = db.transaction(this.storeName, 'readwrite');
+    const store = tx.objectStore(this.storeName);
+    for (const entry of entries) {
+      store.delete(entry.id);
+    }
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+}
+
+class LocalStorageBackend implements StorageBackend {
+  readonly name = 'localStorage';
+
+  constructor(private readonly prefix: string) {}
+
+  private indexKey(): string {
+    return `${this.prefix}:index`;
+  }
+
+  private entryKey(id: string): string {
+    return `${this.prefix}:entry:${id}`;
+  }
+
+  private getIndex(): string[] {
+    try {
+      const raw = localStorage.getItem(this.indexKey());
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private setIndex(ids: string[]): void {
+    localStorage.setItem(this.indexKey(), JSON.stringify(ids));
+  }
+
+  async save(entry: StoredSave): Promise<void> {
+    const existing = await this.getBySlot(entry.domain, entry.gameType, entry.slotId);
+    if (existing && existing.id !== entry.id) {
+      await this.removeBySlot(entry.domain, entry.gameType, entry.slotId);
+    }
+
+    localStorage.setItem(this.entryKey(entry.id), JSON.stringify(entry));
+    const index = this.getIndex();
+    if (!index.includes(entry.id)) {
+      index.push(entry.id);
+      this.setIndex(index);
+    }
+  }
+
+  async list(domain: SaveDomain, gameType: string): Promise<StoredSave[]> {
+    const index = this.getIndex();
+    const results: StoredSave[] = [];
+    for (const id of index) {
+      const entry = await this.getById(id);
+      if (entry && entry.domain === domain && entry.gameType === gameType) {
+        results.push(entry);
+      }
+    }
+    results.sort((a, b) => (b.seq ?? 0) - (a.seq ?? 0));
+    return results;
+  }
+
+  async getBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<StoredSave | null> {
+    const index = this.getIndex();
+    for (const id of index) {
+      const entry = await this.getById(id);
+      if (entry && entry.domain === domain && entry.gameType === gameType && entry.slotId === slotId) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  async removeBySlot(domain: SaveDomain, gameType: string, slotId: string): Promise<void> {
+    const existing = await this.getBySlot(domain, gameType, slotId);
+    if (!existing) return;
+    localStorage.removeItem(this.entryKey(existing.id));
+    const nextIndex = this.getIndex().filter((id) => id !== existing.id);
+    this.setIndex(nextIndex);
+  }
+
+  async clear(domain?: SaveDomain, gameType?: string): Promise<void> {
+    if (!domain || !gameType) {
+      const index = this.getIndex();
+      for (const id of index) {
+        localStorage.removeItem(this.entryKey(id));
+      }
+      localStorage.removeItem(this.indexKey());
+      return;
+    }
+
+    const entries = await this.list(domain, gameType);
+    for (const entry of entries) {
+      localStorage.removeItem(this.entryKey(entry.id));
+    }
+    const removeIds = new Set(entries.map((e) => e.id));
+    const nextIndex = this.getIndex().filter((id) => !removeIds.has(id));
+    this.setIndex(nextIndex);
+  }
+
+  private async getById(id: string): Promise<StoredSave | null> {
+    try {
+      const raw = localStorage.getItem(this.entryKey(id));
+      return raw ? (JSON.parse(raw) as StoredSave) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function serializeWithVersion<TState, TSerialized>(
+  serializer: SaveSerializer<TState, TSerialized>,
+  state: TState,
+): VersionedPayload<TSerialized> {
+  return {
+    schemaVersion: serializer.schemaVersion,
+    data: serializer.serialize(state),
+  };
+}
+
+export function deserializeWithVersion<TState, TSerialized>(
+  serializer: SaveSerializer<TState, TSerialized>,
+  payload: VersionedPayload<TSerialized>,
+): TState {
+  if (payload.schemaVersion !== serializer.schemaVersion) {
+    throw new Error(
+      `Incompatible save version: expected ${serializer.schemaVersion}, got ${payload.schemaVersion}`,
+    );
+  }
+  return serializer.deserialize(payload.data);
+}
+
+export class SaveLoadStore {
+  private backend: StorageBackend | null = null;
+  private initPromise: Promise<void> | null = null;
+  private readonly dbName: string;
+  private readonly storeName: string;
+  private readonly localStoragePrefix: string;
+  private seqCounter: number = 0;
+
+  constructor(options: SaveLoadStoreOptions = {}) {
+    this.dbName = options.dbName ?? DEFAULT_DB_NAME;
+    this.storeName = options.storeName ?? DEFAULT_STORE_NAME;
+    this.localStoragePrefix = options.localStoragePrefix ?? DEFAULT_LS_PREFIX;
+  }
+
+  private init(): Promise<void> {
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = (async () => {
+      if (typeof indexedDB !== 'undefined') {
+        try {
+          const backend = new IndexedDBBackend(this.dbName, this.storeName);
+          await backend.list('run-checkpoint', '__probe__');
+          this.backend = backend;
+          return;
+        } catch (e) {
+          console.warn('[SaveLoadStore] IndexedDB unavailable, falling back to localStorage:', e);
+        }
+      }
+
+      if (typeof localStorage !== 'undefined') {
+        try {
+          const probeKey = `${this.localStoragePrefix}:__probe__`;
+          localStorage.setItem(probeKey, '1');
+          localStorage.removeItem(probeKey);
+          this.backend = new LocalStorageBackend(this.localStoragePrefix);
+          return;
+        } catch (e) {
+          console.warn('[SaveLoadStore] localStorage unavailable:', e);
+        }
+      }
+
+      console.warn('[SaveLoadStore] No storage backend available. Saves will not persist.');
+    })();
+
+    return this.initPromise;
+  }
+
+  private generateId(domain: SaveDomain, gameType: string, slotId: string): string {
+    const timestamp = Date.now();
+    const random = Math.random().toString(36).slice(2, 8);
+    return `${domain}:${gameType}:${slotId}:${timestamp}:${random}`;
+  }
+
+  async save<T>(
+    domain: SaveDomain,
+    gameType: string,
+    slotId: string,
+    schemaVersion: number,
+    payload: T,
+  ): Promise<StoredSave<T> | null> {
+    await this.init();
+    if (!this.backend) return null;
+
+    const entry: StoredSave<T> = {
+      id: this.generateId(domain, gameType, slotId),
+      slotId,
+      gameType,
+      domain,
+      schemaVersion,
+      savedAt: new Date().toISOString(),
+      seq: this.seqCounter++,
+      payload,
+    };
+    await this.backend.save(entry as StoredSave);
+    return entry;
+  }
+
+  async load<T>(domain: SaveDomain, gameType: string, slotId: string): Promise<StoredSave<T> | null> {
+    await this.init();
+    if (!this.backend) return null;
+    return (await this.backend.getBySlot(domain, gameType, slotId)) as StoredSave<T> | null;
+  }
+
+  async list<T>(domain: SaveDomain, gameType: string): Promise<StoredSave<T>[]> {
+    await this.init();
+    if (!this.backend) return [];
+    return (await this.backend.list(domain, gameType)) as StoredSave<T>[];
+  }
+
+  async remove(domain: SaveDomain, gameType: string, slotId: string): Promise<void> {
+    await this.init();
+    if (!this.backend) return;
+    await this.backend.removeBySlot(domain, gameType, slotId);
+  }
+
+  async clear(domain?: SaveDomain, gameType?: string): Promise<void> {
+    await this.init();
+    if (!this.backend) return;
+    await this.backend.clear(domain, gameType);
+  }
+
+  async getBackendName(): Promise<string | null> {
+    await this.init();
+    return this.backend?.name ?? null;
+  }
+
+  async saveSerialized<TState, TSerialized>(
+    domain: SaveDomain,
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+    state: TState,
+  ): Promise<StoredSave<VersionedPayload<TSerialized>> | null> {
+    const payload = serializeWithVersion(serializer, state);
+    return this.save(domain, gameType, slotId, serializer.schemaVersion, payload);
+  }
+
+  async loadSerialized<TState, TSerialized>(
+    domain: SaveDomain,
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+  ): Promise<TState | null> {
+    const stored = await this.load<VersionedPayload<TSerialized>>(domain, gameType, slotId);
+    if (!stored) return null;
+    if (stored.schemaVersion !== serializer.schemaVersion) {
+      throw new Error(
+        `Incompatible save version: expected ${serializer.schemaVersion}, got ${stored.schemaVersion}`,
+      );
+    }
+    return deserializeWithVersion(serializer, stored.payload);
+  }
+
+  async saveRunCheckpoint<TState, TSerialized>(
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+    state: TState,
+  ): Promise<StoredSave<VersionedPayload<TSerialized>> | null> {
+    return this.saveSerialized('run-checkpoint', gameType, slotId, serializer, state);
+  }
+
+  async loadRunCheckpoint<TState, TSerialized>(
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+  ): Promise<TState | null> {
+    return this.loadSerialized('run-checkpoint', gameType, slotId, serializer);
+  }
+
+  async saveCampaignProgress<TState, TSerialized>(
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+    state: TState,
+  ): Promise<StoredSave<VersionedPayload<TSerialized>> | null> {
+    return this.saveSerialized('campaign', gameType, slotId, serializer, state);
+  }
+
+  async loadCampaignProgress<TState, TSerialized>(
+    gameType: string,
+    slotId: string,
+    serializer: SaveSerializer<TState, TSerialized>,
+  ): Promise<TState | null> {
+    return this.loadSerialized('campaign', gameType, slotId, serializer);
+  }
+}

--- a/src/core-engine/index.ts
+++ b/src/core-engine/index.ts
@@ -35,6 +35,20 @@ export { CompoundCommand, UndoRedoManager } from './UndoRedoManager';
 export type { StoredTranscript, TranscriptStoreOptions } from './TranscriptStore';
 export { TranscriptStore } from './TranscriptStore';
 
+// Save/load persistence
+export type {
+  SaveDomain,
+  StoredSave,
+  SaveLoadStoreOptions,
+  VersionedPayload,
+  SaveSerializer,
+} from './SaveLoad';
+export {
+  SaveLoadStore,
+  serializeWithVersion,
+  deserializeWithVersion,
+} from './SaveLoad';
+
 // Game event system
 export type {
   TurnStartedPayload,

--- a/tests/core-engine/SaveLoad.test.ts
+++ b/tests/core-engine/SaveLoad.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  SaveLoadStore,
+  serializeWithVersion,
+  deserializeWithVersion,
+  type SaveSerializer,
+} from '../../src/core-engine/SaveLoad';
+
+function createLocalStorageMock(): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => data.clear(),
+    get length() {
+      return data.size;
+    },
+    key: (index: number) => [...data.keys()][index] ?? null,
+  };
+}
+
+describe('SaveLoadStore', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', undefined);
+    vi.stubGlobal('localStorage', createLocalStorageMock());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('saves and loads run checkpoints by slot', async () => {
+    const store = new SaveLoadStore();
+    const saved = await store.save('run-checkpoint', 'main-street', 'slot-a', 1, { turn: 2 });
+    expect(saved).not.toBeNull();
+
+    const loaded = await store.load<{ turn: number }>('run-checkpoint', 'main-street', 'slot-a');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.payload.turn).toBe(2);
+  });
+
+  it('keeps run and campaign domains separated', async () => {
+    const store = new SaveLoadStore();
+    await store.save('run-checkpoint', 'main-street', 'slot-a', 1, { value: 'run' });
+    await store.save('campaign', 'main-street', 'slot-a', 1, { value: 'campaign' });
+
+    const run = await store.load<{ value: string }>('run-checkpoint', 'main-street', 'slot-a');
+    const campaign = await store.load<{ value: string }>('campaign', 'main-street', 'slot-a');
+    expect(run!.payload.value).toBe('run');
+    expect(campaign!.payload.value).toBe('campaign');
+  });
+
+  it('replaces existing slot with newer save', async () => {
+    const store = new SaveLoadStore();
+    await store.save('run-checkpoint', 'main-street', 'slot-a', 1, { turn: 1 });
+    await store.save('run-checkpoint', 'main-street', 'slot-a', 1, { turn: 3 });
+
+    const list = await store.list('run-checkpoint', 'main-street');
+    expect(list).toHaveLength(1);
+    expect((list[0].payload as { turn: number }).turn).toBe(3);
+  });
+
+  it('returns localStorage backend name when IndexedDB is unavailable', async () => {
+    const store = new SaveLoadStore();
+    expect(await store.getBackendName()).toBe('localStorage');
+  });
+
+  it('returns null backend when no storage exists', async () => {
+    vi.stubGlobal('indexedDB', undefined);
+    vi.stubGlobal('localStorage', undefined);
+    const store = new SaveLoadStore();
+
+    expect(await store.getBackendName()).toBeNull();
+    expect(await store.save('run-checkpoint', 'main-street', 'slot-a', 1, { a: 1 })).toBeNull();
+  });
+});
+
+describe('versioned serializer helpers', () => {
+  const serializer: SaveSerializer<{ n: number }, { n: number }> = {
+    schemaVersion: 7,
+    serialize: (state) => ({ n: state.n }),
+    deserialize: (data) => ({ n: data.n }),
+  };
+
+  it('round-trips with matching version', () => {
+    const payload = serializeWithVersion(serializer, { n: 42 });
+    const restored = deserializeWithVersion(serializer, payload);
+    expect(restored).toEqual({ n: 42 });
+  });
+
+  it('rejects incompatible versions', () => {
+    expect(() =>
+      deserializeWithVersion(serializer, {
+        schemaVersion: 8,
+        data: { n: 1 },
+      }),
+    ).toThrow(/Incompatible save version/);
+  });
+});

--- a/tests/core-engine/index.test.ts
+++ b/tests/core-engine/index.test.ts
@@ -13,6 +13,9 @@ import {
   UndoRedoManager,
   CompoundCommand,
   createSeededRng,
+  SaveLoadStore,
+  serializeWithVersion,
+  deserializeWithVersion,
 } from '../../src/core-engine/index';
 
 describe('core-engine barrel exports', () => {
@@ -46,6 +49,12 @@ describe('core-engine barrel exports', () => {
     const val = rng();
     expect(val).toBeGreaterThanOrEqual(0);
     expect(val).toBeLessThan(1);
+  });
+
+  it('should export save/load infrastructure', () => {
+    expect(typeof SaveLoadStore).toBe('function');
+    expect(typeof serializeWithVersion).toBe('function');
+    expect(typeof deserializeWithVersion).toBe('function');
   });
 
   it('should work end-to-end through barrel exports', () => {

--- a/tests/main-street/save-load.test.ts
+++ b/tests/main-street/save-load.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SaveLoadStore } from '../../src/core-engine';
+import { setupMainStreetGame } from '../../example-games/main-street/MainStreetState';
+import {
+  executeDayStart,
+  executeAction,
+  processEndOfTurn,
+} from '../../example-games/main-street/MainStreetEngine';
+import {
+  createDefaultCampaignProgress,
+  loadCampaignProgress,
+  loadTurnStartCheckpoint,
+  mainStreetStateSerializer,
+  saveCampaignProgress,
+  saveTurnStartCheckpoint,
+} from '../../example-games/main-street/MainStreetSaveLoad';
+
+function createLocalStorageMock(): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => data.clear(),
+    get length() {
+      return data.size;
+    },
+    key: (index: number) => [...data.keys()][index] ?? null,
+  };
+}
+
+describe('Main Street save/load integration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', undefined);
+    vi.stubGlobal('localStorage', createLocalStorageMock());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('restores turn-start checkpoint deterministically', async () => {
+    const store = new SaveLoadStore();
+    const state = setupMainStreetGame({ seed: 'save-load-turn-start' });
+
+    executeDayStart(state);
+    const card = state.market.business[0];
+    executeAction(state, { type: 'buy-business', cardId: card.id, slotIndex: 0 });
+    processEndOfTurn(state);
+
+    await saveTurnStartCheckpoint(store, state);
+    const restored = await loadTurnStartCheckpoint(store);
+    expect(restored).not.toBeNull();
+
+    const expected = setupMainStreetGame({ seed: 'save-load-turn-start' });
+    executeDayStart(expected);
+    executeAction(expected, { type: 'buy-business', cardId: card.id, slotIndex: 0 });
+    processEndOfTurn(expected);
+
+    expect(restored!.turn).toBe(expected.turn);
+    expect(restored!.phase).toBe(expected.phase);
+    expect(restored!.resourceBank).toEqual(expected.resourceBank);
+    expect(restored!.streetGrid.map((b) => b?.id ?? null)).toEqual(
+      expected.streetGrid.map((b) => b?.id ?? null),
+    );
+  });
+
+  it('rejects incompatible checkpoint version', async () => {
+    const store = new SaveLoadStore();
+    const state = setupMainStreetGame({ seed: 'save-load-version-mismatch' });
+    const payload = {
+      schemaVersion: 999,
+      data: mainStreetStateSerializer.serialize(state),
+    };
+
+    await store.save('run-checkpoint', 'main-street', 'turn-start', payload.schemaVersion, payload);
+
+    await expect(loadTurnStartCheckpoint(store)).rejects.toThrow(/Incompatible save version/);
+  });
+
+  it('persists and restores campaign progression separately from run checkpoint', async () => {
+    const store = new SaveLoadStore();
+    const progress = createDefaultCampaignProgress();
+    progress.totalRuns = 12;
+    progress.totalWins = 7;
+    progress.persistentReputation = 31;
+    progress.unlockedTiers.push('tier-2');
+
+    await saveCampaignProgress(store, progress);
+    const loaded = await loadCampaignProgress(store);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.totalRuns).toBe(12);
+    expect(loaded!.totalWins).toBe(7);
+    expect(loaded!.persistentReputation).toBe(31);
+    expect(loaded!.unlockedTiers).toContain('tier-2');
+
+    const runSaves = await store.list('run-checkpoint', 'main-street');
+    expect(runSaves).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add core engine save/load infrastructure (`SaveLoadStore`) with IndexedDB primary storage, localStorage fallback, domain separation (`run-checkpoint` vs `campaign`), and versioned serializer helpers
- export the save/load API from the core barrel so games can consume a stable engine surface for serialize/deserialize + backend operations
- add Main Street adapters for turn-start checkpoint and campaign progression persistence, including deterministic restore support (`numericSeed` + `rngCalls`) and integration tests for round-trip + incompatible-version rejection

## Validation
- `npm test`
- `npm run build`