### PR TITLE
CG-0MMLDBB070D8LO7T: Fix Activity Log on new-game / restart

### DIFF
--- a/example-games/main-street/scenes/MainStreetScene.ts
+++ b/example-games/main-street/scenes/MainStreetScene.ts
@@ -198,6 +198,13 @@ export class MainStreetScene extends CardGameScene {
     this.pendingBusinessCard = null;
     this.overlayObjects = [];
 
+    // Reset activity-log panel state in case this scene instance is restarted.
+    this.logScrollOffset = 0;
+    this.logMaxScroll = 0;
+    this.logTotalContentH = 0;
+    this.logAutoScroll = true;
+    this.logPrevEntryCount = 0;
+
     this.detectReplayMode();
     this.initEventSystem();
 
@@ -323,6 +330,7 @@ export class MainStreetScene extends CardGameScene {
     this.updateLogMask();
 
     // Mouse-wheel scroll for the log panel
+    this.input.off('wheel', this.handleLogWheel, this);
     this.input.on('wheel', this.handleLogWheel, this);
   }
 
@@ -1356,9 +1364,13 @@ export class MainStreetScene extends CardGameScene {
     const visibleH = LOG_H - LOG_TITLE_H - 4;
     this.logMaxScroll = Math.max(0, this.logTotalContentH - visibleH);
 
-    // Auto-scroll to bottom if we were already at the bottom
-    if (hadAutoScroll && this.logMaxScroll > 0) {
+    // Keep scroll position valid for the current content height.
+    // On scene restart we can transition from a long previous run to a short
+    // new log; without clamping, stale offsets can hide all entries.
+    if (hadAutoScroll) {
       this.logScrollOffset = this.logMaxScroll;
+    } else {
+      this.logScrollOffset = Phaser.Math.Clamp(this.logScrollOffset, 0, this.logMaxScroll);
     }
 
     this.applyLogScroll();

--- a/tests/main-street/MainStreetScene.browser.test.ts
+++ b/tests/main-street/MainStreetScene.browser.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Phaser from 'phaser';
+
+import { waitForScene } from '../helpers/waitForScene';
+import { executeDayStart, processEndOfTurn } from '../../example-games/main-street/MainStreetEngine';
+
+async function bootGame(): Promise<Phaser.Game> {
+  let container = document.getElementById('game-container');
+  if (container) container.remove();
+
+  container = document.createElement('div');
+  container.id = 'game-container';
+  document.body.appendChild(container);
+
+  const { createMainStreetGame } = await import('../../example-games/main-street/createMainStreetGame');
+  const game = createMainStreetGame();
+  await waitForScene(game, 'MainStreetScene');
+  return game;
+}
+
+function destroyGame(game: Phaser.Game | null): void {
+  if (game) {
+    game.destroy(true, false);
+  }
+  const container = document.getElementById('game-container');
+  if (container) container.remove();
+}
+
+describe('MainStreetScene browser tests', () => {
+  let game: Phaser.Game | null = null;
+
+  afterEach(() => {
+    destroyGame(game);
+    game = null;
+  });
+
+  it('re-renders activity log after scene restart', async () => {
+    game = await bootGame();
+    const scene = game.scene.getScene('MainStreetScene') as Phaser.Scene & Record<string, unknown>;
+
+    scene.logPrevEntryCount = 1;
+    scene.logScrollOffset = 9999;
+    scene.logAutoScroll = false;
+
+    scene.scene.restart();
+    await waitForScene(game, 'MainStreetScene');
+
+    const restarted = game.scene.getScene('MainStreetScene') as Phaser.Scene & Record<string, unknown>;
+    const state = restarted.state as { activityLog: Array<{ text: string }> };
+    expect(state.activityLog).toHaveLength(1);
+
+    const logContentContainer = restarted.logContentContainer as Phaser.GameObjects.Container;
+    const textEntries = logContentContainer.list.filter((obj) => obj instanceof Phaser.GameObjects.Text) as Phaser.GameObjects.Text[];
+
+    expect(textEntries.some((entry) => entry.text === 'Turn 1')).toBe(true);
+    expect(logContentContainer.y).toBeGreaterThan(0);
+  });
+
+  it('shows new entries for the restarted run', async () => {
+    game = await bootGame();
+    const scene = game.scene.getScene('MainStreetScene') as Phaser.Scene & Record<string, unknown>;
+
+    scene.scene.restart();
+    await waitForScene(game, 'MainStreetScene');
+
+    const restarted = game.scene.getScene('MainStreetScene') as Phaser.Scene & Record<string, unknown>;
+    const state = restarted.state as Parameters<typeof processEndOfTurn>[0];
+
+    processEndOfTurn(state);
+    executeDayStart(state);
+    (restarted.refreshAll as () => void)();
+
+    const logContentContainer = restarted.logContentContainer as Phaser.GameObjects.Container;
+    const textEntries = logContentContainer.list.filter((obj) => obj instanceof Phaser.GameObjects.Text) as Phaser.GameObjects.Text[];
+
+    expect(textEntries.some((entry) => entry.text === 'Turn 2')).toBe(true);
+  });
+});

--- a/tests/main-street/activity-log.test.ts
+++ b/tests/main-street/activity-log.test.ts
@@ -103,6 +103,21 @@ describe('Activity Log', () => {
       const state = createTestState();
       expect(state.activityLog).toEqual([]);
     });
+
+    it('should start a new game with a fresh log and then add new entries', () => {
+      const firstGame = createTestState('activity-log-first-game');
+      executeDayStart(firstGame);
+      processEndOfTurn(firstGame);
+      expect(firstGame.activityLog.length).toBeGreaterThan(0);
+
+      const secondGame = createTestState('activity-log-second-game');
+      expect(secondGame.activityLog).toEqual([]);
+
+      executeDayStart(secondGame);
+      expect(secondGame.activityLog).toHaveLength(1);
+      expect(secondGame.activityLog[0].type).toBe('turn-header');
+      expect(secondGame.activityLog[0].text).toBe('Turn 1');
+    });
   });
 
   describe('turn headers', () => {


### PR DESCRIPTION
## Summary

Small fix to ensure the Main Street Activity Log is visible after starting a new game or restarting the scene. Resets log UI state on scene create/restart and clamps stale scroll offsets. Adds unit and browser regression tests.

## Changes

- example-games/main-street/scenes/MainStreetScene.ts
- tests/main-street/activity-log.test.ts
- tests/main-street/MainStreetScene.browser.test.ts

## Validation

Ran 
> tableau-card-engine@0.1.0 test
> vitest run --project unit && vitest run --project browser


 RUN  v3.2.4 /home/rgardler/projects/Tableau-Card-Engine

stdout | tests/core-engine/autoSaveTranscript.test.ts > autoSaveTranscript > calls store.save with the correct gameType and transcript
[golf] Transcript saved (golf-001) via golf

 ✓ |unit| tests/core-engine/SoundManager.test.ts (27 tests) 127ms
 ✓ |unit| tests/core-engine/TranscriptRecorder.test.ts (16 tests) 189ms
 ✓ |unit| tests/the-mind/ai-strategy.test.ts (70 tests) 86ms
 ✓ |unit| tests/feudalism/AiStrategy.test.ts (14 tests) 84ms
 ✓ |unit| tests/core-engine/TranscriptStore.test.ts (23 tests) 309ms
 ✓ |unit| tests/golf/GameTranscript.test.ts (14 tests) 158ms
 ✓ |unit| tests/core-engine/autoSaveTranscript.test.ts (8 tests) 366ms
 ✓ |unit| tests/lost-cities/lost-cities-ai.test.ts (22 tests) 124ms
 ✓ |unit| tests/the-mind/auto-play.test.ts (33 tests) 193ms
 ✓ |unit| tests/golf/Integration.test.ts (19 tests) 185ms
 ✓ |unit| tests/the-mind/integration.test.ts (33 tests) 251ms
 ✓ |unit| tests/main-street/market.integration.test.ts (14 tests) 166ms
 ✓ |unit| tests/core-engine/SeededRng.test.ts (8 tests) 96ms
 ✓ |unit| tests/beleaguered-castle/Integration.test.ts (30 tests) 657ms
 ✓ |unit| tests/core-engine/UndoRedoManager.test.ts (24 tests) 22ms
 ✓ |unit| tests/core-engine/GameEventEmitter.test.ts (50 tests) 43ms
 ✓ |unit| tests/feudalism/FeudalismCards.test.ts (52 tests) 65ms
 ✓ |unit| tests/main-street/challenges.test.ts (53 tests) 57ms
 ✓ |unit| tests/beleaguered-castle/BeleagueredCastleRules.test.ts (84 tests) 67ms
 ✓ |unit| tests/ui/GameSelectorScene.test.ts (23 tests) 67ms
 ✓ |unit| tests/main-street/market.test.ts (33 tests) 50ms
 ✓ |unit| tests/the-mind/game-state.test.ts (72 tests) 90ms
 ✓ |unit| tests/feudalism/FeudalismGame.test.ts (55 tests) 73ms
 ✓ |unit| tests/main-street/turnflow.test.ts (59 tests) 75ms
 ✓ |unit| tests/main-street/monte-carlo-balance.test.ts (1 test) 60ms
 ✓ |unit| tests/main-street/game-state.test.ts (37 tests) 46ms
 ✓ |unit| tests/ui/CardGameScene.test.ts (18 tests) 40ms
 ✓ |unit| tests/rule-engine/LegalityResult.test.ts (6 tests) 84ms
 ✓ |unit| tests/card-system/Deck.test.ts (19 tests) 23ms
 ✓ |unit| tests/lost-cities/lost-cities-cards.test.ts (44 tests) 31ms
 ✓ |unit| tests/replay/adapters.test.ts (72 tests) 65ms
 ✓ |unit| tests/main-street/expanded-card-pool.test.ts (65 tests) 60ms
 ✓ |unit| tests/lost-cities/lost-cities-game.test.ts (40 tests) 44ms
 ✓ |unit| tests/ui/SceneHeader.test.ts (24 tests) 37ms
 ✓ |unit| tests/main-street/integration.test.ts (24 tests) 58ms
 ✓ |unit| tests/the-mind/mind-card.test.ts (27 tests) 32ms
 ✓ |unit| tests/main-street/difficulty-presets.test.ts (51 tests) 63ms
 ✓ |unit| tests/sushi-go/SushiGoGame.test.ts (21 tests) 37ms
 ✓ |unit| tests/card-system/Pile.test.ts (19 tests) 30ms
 ✓ |unit| tests/main-street/save-load.test.ts (5 tests) 35ms
 ✓ |unit| tests/the-mind/mind-card-renderer.test.ts (37 tests) 28ms
 ✓ |unit| tests/main-street/upgrades.test.ts (18 tests) 42ms
 ✓ |unit| tests/golf/AiStrategy.test.ts (20 tests) 40ms
 ✓ |unit| tests/the-mind/transcript.test.ts (32 tests) 48ms
 ✓ |unit| tests/golf/GolfRules.test.ts (22 tests) 22ms
 ✓ |unit| tests/core-engine/TurnSequencer.test.ts (36 tests) 60ms
 ✓ |unit| tests/ui/flipCard.test.ts (19 tests) 30ms
 ✓ |unit| tests/ai/AiUtils.test.ts (14 tests) 37ms
 ✓ |unit| tests/lost-cities/lost-cities-rules.test.ts (32 tests) 41ms
 ✓ |unit| tests/golf/GolfGame.test.ts (14 tests) 28ms
 ✓ |unit| tests/ui/Overlay.test.ts (21 tests) 57ms
 ✓ |unit| tests/main-street/activity-log.test.ts (22 tests) 41ms
 ✓ |unit| tests/ui/shakeIllegalMove.test.ts (15 tests) 31ms
 ✓ |unit| tests/sushi-go/SushiGoScoring.test.ts (56 tests) 47ms
 ✓ |unit| tests/golf/GolfGrid.test.ts (19 tests) 18ms
 ✓ |unit| tests/core-engine/PhaserEventBridge.test.ts (13 tests) 29ms
 ✓ |unit| tests/sushi-go/AiStrategy.test.ts (15 tests) 18ms
 ✓ |unit| tests/sushi-go/SushiGoCards.test.ts (19 tests) 22ms
 ✓ |unit| tests/ui/PhaseManager.test.ts (21 tests) 30ms
 ✓ |unit| tests/main-street/adjacency.test.ts (34 tests) 30ms
 ✓ |unit| tests/core-engine/SaveLoad.test.ts (7 tests) 20ms
 ✓ |unit| tests/ui/SettingsPanel.test.ts (11 tests) 19ms
 ✓ |unit| tests/ui/layoutCardPositions.test.ts (13 tests) 18ms
 ✓ |unit| tests/lost-cities/lost-cities-scoring.test.ts (26 tests) 29ms
 ✓ |unit| tests/core-engine/setup-options.test.ts (29 tests) 20ms
 ✓ |unit| tests/golf/GolfScoring.test.ts (18 tests) 15ms
 ✓ |unit| tests/ai/AiStrategy.test.ts (7 tests) 8ms
 ✓ |unit| tests/ai/index.test.ts (5 tests) 26ms
 ✓ |unit| tests/core-engine/GameState.test.ts (12 tests) 19ms
 ✓ |unit| tests/ui/createCardGame.test.ts (16 tests) 29ms
 ✓ |unit| tests/card-system/index.test.ts (7 tests) 14ms
 ✓ |unit| tests/ui/CardTextureHelpers.test.ts (29 tests) 37ms
 ✓ |unit| tests/core-engine/TranscriptTypes.test.ts (9 tests) 11ms
 ✓ |unit| tests/card-system/rankValue.test.ts (5 tests) 11ms
 ✓ |unit| tests/card-system/Card.test.ts (5 tests) 10ms
 ✓ |unit| tests/sushi-go-icons.test.ts (1 test) 6ms
 ✓ |unit| tests/ui/HelpPanel.test.ts (6 tests) 8ms
 ✓ |unit| tests/core-engine/index.test.ts (7 tests) 9ms
 ✓ |unit| tests/sushi-go-wasabi.test.ts (2 tests) 7ms
 ✓ |unit| tests/smoke.test.ts (2 tests) 5ms
 ✓ |unit| tests/lost-cities/lost-cities-transcript.test.ts (21 tests) 4203ms
   ✓ Full match transcript > produces a valid transcript for a RandomStrategy AI-vs-AI match  4024ms
 ✓ |unit| tests/replay/replay.test.ts (16 tests | 5 skipped) 11029ms
   ✓ Replay CLI -- transcript validation > should show help text when --help flag is provided  1074ms
   ✓ Replay CLI -- transcript validation > should exit with error when transcript file does not exist  1183ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for invalid JSON  1154ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for wrong transcript version  869ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for missing initialState  562ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at has no value  587ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at is negative  635ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at is a decimal  634ms
   ✓ Replay CLI -- --stop-at argument validation > should show --stop-at in help text  666ms
   ✓ Replay CLI -- v1 transcript handling > should reject v1 transcript when --stop-at is used  566ms
   ✓ Replay CLI -- v1 transcript handling > should accept v1 transcript for regular replay (no --stop-at)  3092ms

 Test Files  82 passed (82)
      Tests  2037 passed | 5 skipped (2042)
   Start at  03:01:47
   Duration  11.78s (transform 5.62s, setup 0ms, collect 15.51s, tests 20.60s, environment 32ms, prepare 13.73s)


 RUN  v3.2.4 /home/rgardler/projects/Tableau-Card-Engine

stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should lay out cards without overlapping grids or piles
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should start in waiting-for-draw and allow drawing from stock or discard
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should transition to waiting-for-move after clicking discard pile
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should execute a swap move when clicking a grid card after drawing
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should support full discard-and-flip flow including face-up card rejection
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should execute AI turn after human and update scores correctly
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should not allow clicks during AI turn
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should complete a full game with multiple turns
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfInteraction.browser.test.ts (8 tests) 31972ms
   ✓ GolfScene interaction tests > should lay out cards without overlapping grids or piles  1341ms
   ✓ GolfScene interaction tests > should start in waiting-for-draw and allow drawing from stock or discard  1260ms
   ✓ GolfScene interaction tests > should transition to waiting-for-move after clicking discard pile  1243ms
   ✓ GolfScene interaction tests > should execute a swap move when clicking a grid card after drawing  1777ms
   ✓ GolfScene interaction tests > should support full discard-and-flip flow including face-up card rejection  1840ms
   ✓ GolfScene interaction tests > should execute AI turn after human and update scores correctly  4872ms
   ✓ GolfScene interaction tests > should not allow clicks during AI turn  1345ms
   ✓ GolfScene interaction tests > should complete a full game with multiple turns  18293ms
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-03-11T10-02-33.244Z.json
stdout | unknown test
[GolfScene] Transcript saved (golf-1773223353235-w5mnar) via golf
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should lay out 8 tableau columns without horizontal overlap
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should keep all cards and foundations within the game viewport
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should not overlap foundation slots with tableau columns
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts (3 tests) 10560ms
   ✓ BeleagueredCastleScene layout regression tests > should lay out 8 tableau columns without horizontal overlap  3703ms
   ✓ BeleagueredCastleScene layout regression tests > should keep all cards and foundations within the game viewport  3456ms
   ✓ BeleagueredCastleScene layout regression tests > should not overlap foundation slots with tableau columns  3401ms
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit turn-started on create and expose emitter globally
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-03-11T10-02-53.069Z.json
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end
[GolfScene] Transcript saved (golf-1773223372833-tz2toj) via golf
 ✓ |browser (chromium)| tests/golf/GolfEvents.browser.test.ts (2 tests) 9084ms
   ✓ GolfScene event integration > should emit turn-started on create and expose emitter globally  3133ms
   ✓ GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end  5950ms
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should render a canvas element inside the game container
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should create the GolfScene as the active scene
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should create 18 card sprites (9 per player grid)
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should display text elements for labels, scores, and instructions
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should have interactive stock and discard pile sprites
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should not have any console errors during initialization
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfScene.browser.test.ts (6 tests) 7640ms
   ✓ GolfScene browser tests > should render a canvas element inside the game container  1315ms
   ✓ GolfScene browser tests > should create the GolfScene as the active scene  1387ms
   ✓ GolfScene browser tests > should create 18 card sprites (9 per player grid)  1192ms
   ✓ GolfScene browser tests > should display text elements for labels, scores, and instructions  1247ms
   ✓ GolfScene browser tests > should have interactive stock and discard pile sprites  1167ms
   ✓ GolfScene browser tests > should not have any console errors during initialization  1331ms
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should show loss overlay buttons that are interactive
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should restart the scene when "Try Again" is clicked via DOM pointer event
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should show win overlay buttons that respond to DOM clicks
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should have an interactive input blocker at overlay depth
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/the-mind/TheMindOverlay.browser.test.ts (4 tests) 6299ms
   ✓ The Mind overlay button tests > should show loss overlay buttons that are interactive  1383ms
   ✓ The Mind overlay button tests > should restart the scene when "Try Again" is clicked via DOM pointer event  1658ms
   ✓ The Mind overlay button tests > should show win overlay buttons that respond to DOM clicks  1664ms
   ✓ The Mind overlay button tests > should have an interactive input blocker at overlay depth  1595ms
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should show overlay buttons that exist in the scene children list
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
[GolfScene] Transcript saved (golf-1773223389842-pbw78z) via golf
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-03-11T10-03-10.011Z.json
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-03-11T10-03-11.396Z.json
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
[GolfScene] Transcript saved (golf-1773223391105-cgeco6) via golf
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should have an interactive input blocker behind the overlay
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-03-11T10-03-13.192Z.json
stdout | tests/golf/GolfOverlay.browser.test.ts
[GolfScene] Transcript saved (golf-1773223392983-1iggvf) via golf
 ✓ |browser (chromium)| tests/golf/GolfOverlay.browser.test.ts (3 tests) 5041ms
   ✓ Golf overlay button tests > should show overlay buttons that exist in the scene children list  1692ms
   ✓ Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event  1795ms
   ✓ Golf overlay button tests > should have an interactive input blocker behind the overlay  1554ms
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should render a help button ("?") in the scene
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should have the help panel initially closed (not visible)
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should not produce console errors with the help panel integrated
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/ui/HelpPanel.browser.test.ts (4 tests) 4002ms
   ✓ HelpPanel browser tests > should render a help button ("?") in the scene  1303ms
   ✓ HelpPanel browser tests > should have the help panel initially closed (not visible)  1303ms
   ✓ HelpPanel browser tests > should not produce console errors with the help panel integrated  1348ms
stdout | tests/golf/GolfReplay.browser.test.ts > GolfScene replay mode > should enter replay mode and support loadBoardState()
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfReplay.browser.test.ts > GolfScene replay mode > should throw if loadBoardState() is called outside replay mode
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfReplay.browser.test.ts (2 tests) 2614ms
   ✓ GolfScene replay mode > should enter replay mode and support loadBoardState()  1409ms
   ✓ GolfScene replay mode > should throw if loadBoardState() is called outside replay mode  1204ms
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should have non-overlapping upper band sections (patrons, market, supply)
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should not overlap player/AI section boxes with action buttons or instruction text
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should not overlap action buttons with instruction text
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/feudalism/FeudalismLayout.browser.test.ts (3 tests) 1030ms
   ✓ FeudalismScene layout regression tests > should have non-overlapping upper band sections (patrons, market, supply)  477ms
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > re-renders activity log after scene restart
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > shows new entries for the restarted run
%c %c %c %c %c Phaser v3.90.0 (WebGL | Web Audio) %c https://phaser.io/v390 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/main-street/MainStreetScene.browser.test.ts (2 tests) 478ms
 ✓ |browser (chromium)| tests/core-engine/PhaserEventBridge.browser.test.ts (6 tests) 3ms

 Test Files  11 passed (11)
      Tests  43 passed (43)
   Start at  03:01:59
   Duration  83.11s (transform 0ms, setup 0ms, collect 1.71s, tests 78.72s, environment 0ms, prepare 662.74s) (unit + browser) and 
> tableau-card-engine@0.1.0 build
> tsc --noEmit && vite build

vite v6.4.1 building for production...
transforming...
✓ 101 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                    0.59 kB │ gzip:   0.37 kB
dist/assets/index-Dk_uiBh6.js  1,780.74 kB │ gzip: 422.55 kB │ map: 11,523.70 kB
✓ built in 7.34s — all checks passed locally.

Related work-item: CG-0MMLDBB070D8LO7T
