### PR TITLE
fix(main-street): Update Synergy types in help text (CG-0MMJST29S0X65FHS)

### DIFF
--- a/example-games/main-street/scenes/MainStreetScene.ts
+++ b/example-games/main-street/scenes/MainStreetScene.ts
@@ -245,7 +245,9 @@ export class MainStreetScene extends CardGameScene {
         body:
           'Food (orange) -- restaurants, cafes\n' +
           'Culture (blue) -- galleries, theaters\n' +
-          'Commerce (green) -- shops, services',
+          'Commerce (green) -- shops, services\n' +
+          'Service (purple) -- salons, clinics\n' +
+          'Entertainment (red) -- cinemas, arcades',
       },
       {
         heading: 'Win / Loss',


### PR DESCRIPTION
This PR updates the Main Street help text to include Service and Entertainment in the Synergy types as part of work item CG-0MMJST29S0X65FHS.

Changes:
- example-games/main-street/scenes/MainStreetScene.ts

No tests were added; this is a documentation/help-text fix.