### PR TITLE
CG-0MP0WPNIT009JOML: Fix Lost Cities require() runtime error

### DIFF
--- a/example-games/lost-cities/scenes/LostCitiesAnimator.ts
+++ b/example-games/lost-cities/scenes/LostCitiesAnimator.ts
@@ -28,7 +28,7 @@ import {
   AI_ANIM_DURATION,
 } from './LostCitiesConstants';
 import { LostCitiesRenderer } from './LostCitiesRenderer';
-import { flipCard, moveGameObject, shakeIllegalMove } from '../../../src/ui';
+import { flipCard, moveGameObject, shakeIllegalMove, FONT_FAMILY } from '../../../src/ui';
 
 export class LostCitiesAnimator {
   private scene: Phaser.Scene;
@@ -234,7 +234,7 @@ export class LostCitiesAnimator {
     const targetX = AI_HAND_CENTER;
     const targetY = HAND_TOP + targetIdx * HAND_OVERLAP + HAND_CARD_H / 2;
 
-    const { FONT_FAMILY } = require('../../../src/ui');
+    // FONT_FAMILY imported from src/ui
     const annotation = this.scene.add.text(sourceX, sourceY - 40, annotationText, {
       fontFamily: FONT_FAMILY,
       fontSize: '16px',

--- a/example-games/lost-cities/scenes/LostCitiesScene.ts
+++ b/example-games/lost-cities/scenes/LostCitiesScene.ts
@@ -38,6 +38,13 @@ import helpContent from '../help-content.json';
 
 import {
   SFX_KEYS,
+  CARD_W,
+  CARD_H,
+  DISCARD_CARD_W,
+  DISCARD_CARD_H,
+  laneX,
+  PLR_EXP_TOP,
+  DISCARD_Y,
   type SceneTurnPhase,
 } from './LostCitiesConstants';
 import { LostCitiesRenderer } from './LostCitiesRenderer';
@@ -68,7 +75,8 @@ export class LostCitiesScene extends CardGameScene {
 
   // ── Preload ─────────────────────────────────────────────
   preload(): void {
-    const { CARD_W, CARD_H, DISCARD_CARD_W, DISCARD_CARD_H } = require('./LostCitiesConstants');
+    // Card dimension constants imported from LostCitiesConstants
+    // (don't use `require` in browser bundles) 
 
     for (const color of EXPEDITION_COLORS) {
       for (let inv = 1; inv <= 3; inv++) {
@@ -182,7 +190,7 @@ export class LostCitiesScene extends CardGameScene {
         const color = this.tooltipManager.colorAtPointerX(pointer.x);
         if (!color) { this.tooltipManager.hideExpeditionTooltip(); return; }
         if (color === this.tooltipManager.currentTooltipColor) return;
-        const { laneX, PLR_EXP_TOP, CARD_H } = require('./LostCitiesConstants');
+        // laneX, PLR_EXP_TOP and CARD_H are imported from LostCitiesConstants
         this.tooltipManager.showExpeditionTooltip(color, {
           x: laneX(EXPEDITION_COLORS.indexOf(color)),
           y: PLR_EXP_TOP + CARD_H / 2,
@@ -197,7 +205,7 @@ export class LostCitiesScene extends CardGameScene {
         const color = this.tooltipManager.colorAtPointerX(pointer.x);
         if (!color) { this.tooltipManager.hideExpeditionTooltip(); return; }
         if (color === this.tooltipManager.currentTooltipColor) return;
-        const { laneX, DISCARD_Y, DISCARD_CARD_H } = require('./LostCitiesConstants');
+        // laneX, DISCARD_Y and DISCARD_CARD_H are imported from LostCitiesConstants
         this.tooltipManager.showExpeditionTooltip(color, {
           x: laneX(EXPEDITION_COLORS.indexOf(color)),
           y: DISCARD_Y + DISCARD_CARD_H / 2,

--- a/example-games/lost-cities/scenes/LostCitiesTurnController.ts
+++ b/example-games/lost-cities/scenes/LostCitiesTurnController.ts
@@ -16,6 +16,7 @@ import type { LCTranscriptRecorder } from '../GameTranscript';
 import {
   AI_DELAY,
   SFX_KEYS,
+  laneX as laneXFn,
   type SceneTurnPhase,
 } from './LostCitiesConstants';
 import type { LostCitiesAnimator } from './LostCitiesAnimator';
@@ -164,8 +165,7 @@ export class LostCitiesTurnController {
   }
 
   private laneX(index: number): number {
-    const { CARD_W, TABLEAU_LEFT, LANE_STEP } = require('./LostCitiesConstants');
-    return TABLEAU_LEFT + index * LANE_STEP + CARD_W / 2;
+    return laneXFn(index);
   }
 
   onDrawPileClick(): void {


### PR DESCRIPTION
Replaces runtime require() calls in Lost Cities scenes with ES module imports to fix 'require is not defined' in browser. See work item CG-0MP0WPNIT009JOML.