### PR TITLE
CG-0MP19J6WE005W356: Refactor TheMind scene setup and add turn-controller tests

### DIFF
--- a/example-games/the-mind/scenes/MindAudioKeys.ts
+++ b/example-games/the-mind/scenes/MindAudioKeys.ts
@@ -1,0 +1,12 @@
+/**
+ * MindAudioKeys -- audio asset keys for The Mind.
+ */
+
+export const SFX_KEYS = {
+  CARD_PLAY: 'mind-sfx-card-play',
+  LIFE_LOST: 'mind-sfx-life-lost',
+  LEVEL_COMPLETE: 'mind-sfx-level-complete',
+  GAME_WIN: 'mind-sfx-game-win',
+  GAME_LOST: 'mind-sfx-game-lost',
+  UI_CLICK: 'mind-sfx-ui-click',
+} as const;

--- a/example-games/the-mind/scenes/MindConstants.ts
+++ b/example-games/the-mind/scenes/MindConstants.ts
@@ -32,16 +32,6 @@ export const DEPTH_UI = 5;
 export const DEPTH_OVERLAY = 2000;
 export const DEPTH_OVERLAY_CONTENT = DEPTH_OVERLAY + 1;
 
-// ── Audio asset keys ────────────────────────────────────────
-export const SFX_KEYS = {
-  CARD_PLAY: 'mind-sfx-card-play',
-  LIFE_LOST: 'mind-sfx-life-lost',
-  LEVEL_COMPLETE: 'mind-sfx-level-complete',
-  GAME_WIN: 'mind-sfx-game-win',
-  GAME_LOST: 'mind-sfx-game-lost',
-  UI_CLICK: 'mind-sfx-ui-click',
-} as const;
-
 // ── Phase state machine ─────────────────────────────────────
 export type GamePhase =
   | 'dealing'

--- a/example-games/the-mind/scenes/MindOverlayManager.ts
+++ b/example-games/the-mind/scenes/MindOverlayManager.ts
@@ -6,7 +6,8 @@ import { GAME_W, GAME_H, FONT_FAMILY, createOverlayBackground, createOverlayButt
 import { MAX_LEVEL } from '../TheMindGameState';
 import type { TheMindSession } from '../TheMindGameState';
 import type { SoundManager, GameEventEmitter } from '../../../src/core-engine';
-import { DEPTH_OVERLAY, DEPTH_OVERLAY_CONTENT, SFX_KEYS } from './MindConstants';
+import { DEPTH_OVERLAY, DEPTH_OVERLAY_CONTENT } from './MindConstants';
+import { SFX_KEYS } from './MindAudioKeys';
 
 export class MindOverlayManager {
   overlayObjects: Phaser.GameObjects.GameObject[] = [];

--- a/example-games/the-mind/scenes/MindTurnController.ts
+++ b/example-games/the-mind/scenes/MindTurnController.ts
@@ -6,7 +6,7 @@ import type { PlayResult, PlayerId, TheMindSession } from '../TheMindGameState';
 import { playCard, isGameOver, getPileTopValue } from '../TheMindGameState';
 import { MindTranscriptRecorder } from '../GameTranscript';
 import type { GameEventEmitter, SoundManager } from '../../../src/core-engine';
-import { SFX_KEYS } from './MindConstants';
+import { SFX_KEYS } from './MindAudioKeys';
 import type { MindAiScheduler } from './MindAiScheduler';
 
 export class MindTurnController {

--- a/example-games/the-mind/scenes/TheMindScene.ts
+++ b/example-games/the-mind/scenes/TheMindScene.ts
@@ -32,10 +32,10 @@ import type { HelpSection } from '../../../src/ui';
 import helpContent from '../help-content.json';
 
 import {
-  SFX_KEYS,
   PRE_PENALTY_PAUSE,
   type GamePhase,
 } from './MindConstants';
+import { SFX_KEYS } from './MindAudioKeys';
 import { MindRenderer } from './MindRenderer';
 import { MindAnimator } from './MindAnimator';
 import { MindAiScheduler } from './MindAiScheduler';
@@ -109,7 +109,23 @@ export class TheMindScene extends CardGameScene {
     this.cameras.main.setBackgroundColor('#1a1a2e');
     this.events.on('shutdown', this.shutdown, this);
 
-    // Reset state for scene restart
+    this.resetSceneState();
+    this.detectReplayMode();
+    this.initEventSystem();
+
+    if (this.replayMode) {
+      this.createReplayView();
+      return;
+    }
+
+    this.createSoundSystem();
+    this.initializeGameControllers();
+    this.createPrimaryView();
+    this.renderInitialState();
+    this.startLevel();
+  }
+
+  private resetSceneState(): void {
     this.phase = 'dealing';
     this.humanCardSprites = [];
     this.aiCardSprites = [];
@@ -120,49 +136,44 @@ export class TheMindScene extends CardGameScene {
 
     const urlParams = new URLSearchParams(window.location.search);
     this.autoPlayEnabled = urlParams.get('autoplay') === 'true';
-    this.detectReplayMode();
+  }
 
-    this.initEventSystem();
+  private createReplayView(): void {
+    this.createHeader();
+    this.createStatusDisplay();
+    this.createPile();
+    this.createInstruction();
+    this.instructionText.setText('');
+    this.levelText.setText('Level 1 / 8');
+    this.livesText.setText('Lives: \u2764\u2764');
+    this.emitStateSettled(0, 'playing');
+  }
 
-    if (this.replayMode) {
-      this.createHeader();
-      this.createStatusDisplay();
-      this.createPile();
-      this.createInstruction();
-      this.instructionText.setText('');
-      this.levelText.setText('Level 1 / 8');
-      this.livesText.setText('Lives: \u2764\u2764');
-      this.emitStateSettled(0, 'playing');
-      return;
-    }
-
-    this.createSoundSystem();
-
+  private initializeGameControllers(): void {
     this.session = setupTheMindGame();
     this.aiPlayer = new MindAiPlayer();
-
     this.recorder = this.createRecorder();
 
-    // Create helpers
     this.mindRenderer = new MindRenderer(this, this.session);
     this.mindAnimator = new MindAnimator(this, this.session, this.mindRenderer, this.soundManager);
     this.aiScheduler = new MindAiScheduler(this, this.session);
     this.overlayManager = new MindOverlayManager(this, this.session, this.gameEvents, this.soundManager);
     this.replayController = new MindReplayController(this, this.mindRenderer, { value: this.replayMode });
     this.turnController = new MindTurnController(this.session, this.recorder, this.gameEvents, this.soundManager);
-
-    // Sync auto-play state with scheduler
     this.aiScheduler.autoPlayEnabled = this.autoPlayEnabled;
+  }
 
-    // Create UI
+  private createPrimaryView(): void {
     this.mindRenderer.createHeader();
     this.mindRenderer.createStatusDisplay();
     this.mindRenderer.createPile();
     this.mindRenderer.createInstruction();
     this.createAutoPlayButton();
     this.initHelpPanel(helpContent as HelpSection[]);
+    this.bindRendererObjects();
+  }
 
-    // Expose renderer display objects on scene for test compatibility
+  private bindRendererObjects(): void {
     this.humanCardSprites = this.mindRenderer.humanCardSprites;
     this.aiCardSprites = this.mindRenderer.aiCardSprites;
     this.aiCountText = this.mindRenderer.aiCountText;
@@ -172,8 +183,9 @@ export class TheMindScene extends CardGameScene {
     this.levelText = this.mindRenderer.levelText;
     this.livesText = this.mindRenderer.livesText;
     this.instructionText = this.mindRenderer.instructionText;
+  }
 
-    // Initial render
+  private renderInitialState(): void {
     this.mindRenderer.renderHumanHand(
       (card) => this.onHumanCardClick(card),
       this.phase,
@@ -182,8 +194,6 @@ export class TheMindScene extends CardGameScene {
     this.mindRenderer.renderAiHand();
     this.mindRenderer.refreshStatus();
     this.mindRenderer.refreshPile();
-
-    this.startLevel();
   }
 
   // ── Header & Status ────────────────────────────────────

--- a/tests/the-mind/mind-turn-controller.test.ts
+++ b/tests/the-mind/mind-turn-controller.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { setupTheMindGame, type TheMindSession } from '../../example-games/the-mind/TheMindGameState';
+import { MindTurnController } from '../../example-games/the-mind/scenes/MindTurnController';
+import { createSeededRng } from '../../src/core-engine/SeededRng';
+
+function createSession(humanHand: number[], aiHand: number[]): TheMindSession {
+  const session = setupTheMindGame({ rng: createSeededRng(7) });
+  session.pile.clear();
+  session.players[0].hand = humanHand.map((value) => ({ value, faceUp: false }));
+  session.players[1].hand = aiHand.map((value) => ({ value, faceUp: false }));
+  return session;
+}
+
+function createController(session: TheMindSession): {
+  controller: MindTurnController;
+  recorder: {
+    recordCardPlay: ReturnType<typeof vi.fn>;
+    recordPenalty: ReturnType<typeof vi.fn>;
+    recordLevelComplete: ReturnType<typeof vi.fn>;
+    finalize: ReturnType<typeof vi.fn>;
+  };
+  gameEvents: { emit: ReturnType<typeof vi.fn> };
+  soundManager: { play: ReturnType<typeof vi.fn> };
+} {
+  const recorder = {
+    recordCardPlay: vi.fn(),
+    recordPenalty: vi.fn(),
+    recordLevelComplete: vi.fn(),
+    finalize: vi.fn(),
+  };
+  const gameEvents = { emit: vi.fn() };
+  const soundManager = { play: vi.fn() };
+
+  return {
+    controller: new MindTurnController(
+      session,
+      recorder as unknown as never,
+      gameEvents as unknown as never,
+      soundManager as unknown as never,
+    ),
+    recorder,
+    gameEvents,
+    soundManager,
+  };
+}
+
+describe('MindTurnController.performPlay', () => {
+  it('uses animation hook and normal callback for valid non-penalty plays', () => {
+    const session = createSession([10], [40]);
+    const { controller, recorder, soundManager } = createController(session);
+
+    const aiScheduler = {
+      removeCardFromAi: vi.fn(),
+      cancelAllTimers: vi.fn(),
+      removePenaltyCards: vi.fn(),
+    };
+
+    const animateCard = vi.fn((playerId: 0 | 1, cardValue: number, onComplete: () => void) => {
+      expect(playerId).toBe(0);
+      expect(cardValue).toBe(10);
+      onComplete();
+    });
+
+    const onPenaltyComplete = vi.fn();
+    const onNormalComplete = vi.fn();
+    const onInvalidPlay = vi.fn();
+
+    controller.performPlay(
+      0,
+      10,
+      aiScheduler as never,
+      animateCard,
+      onPenaltyComplete,
+      onNormalComplete,
+      onInvalidPlay,
+    );
+
+    expect(animateCard).toHaveBeenCalledTimes(1);
+    expect(onNormalComplete).toHaveBeenCalledTimes(1);
+    expect(onPenaltyComplete).not.toHaveBeenCalled();
+    expect(onInvalidPlay).not.toHaveBeenCalled();
+    expect(recorder.recordCardPlay).toHaveBeenCalledTimes(1);
+    expect(soundManager.play).toHaveBeenCalledWith('mind-sfx-card-play');
+    expect(aiScheduler.removeCardFromAi).toHaveBeenCalledWith(10);
+  });
+
+  it('uses animation hook and penalty callback when life is lost', () => {
+    const session = createSession([30], [20]);
+    const { controller, recorder, soundManager } = createController(session);
+
+    const aiScheduler = {
+      removeCardFromAi: vi.fn(),
+      cancelAllTimers: vi.fn(),
+      removePenaltyCards: vi.fn(),
+    };
+
+    const animateCard = vi.fn((_playerId: 0 | 1, _cardValue: number, onComplete: () => void) => {
+      onComplete();
+    });
+
+    const onPenaltyComplete = vi.fn();
+    const onNormalComplete = vi.fn();
+    const onInvalidPlay = vi.fn();
+
+    controller.performPlay(
+      0,
+      30,
+      aiScheduler as never,
+      animateCard,
+      onPenaltyComplete,
+      onNormalComplete,
+      onInvalidPlay,
+    );
+
+    expect(animateCard).toHaveBeenCalledTimes(1);
+    expect(onPenaltyComplete).toHaveBeenCalledTimes(1);
+    expect(onNormalComplete).not.toHaveBeenCalled();
+    expect(soundManager.play).toHaveBeenCalledWith('mind-sfx-life-lost');
+    expect(aiScheduler.cancelAllTimers).toHaveBeenCalledTimes(1);
+    expect(aiScheduler.removePenaltyCards).toHaveBeenCalledTimes(1);
+    expect(recorder.recordPenalty).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes invalid callback for invalid human play and skips animation', () => {
+    const session = createSession([12], [35]);
+    const { controller } = createController(session);
+
+    const aiScheduler = {
+      removeCardFromAi: vi.fn(),
+      cancelAllTimers: vi.fn(),
+      removePenaltyCards: vi.fn(),
+    };
+
+    const animateCard = vi.fn();
+    const onPenaltyComplete = vi.fn();
+    const onNormalComplete = vi.fn();
+    const onInvalidPlay = vi.fn();
+
+    controller.performPlay(
+      0,
+      99,
+      aiScheduler as never,
+      animateCard,
+      onPenaltyComplete,
+      onNormalComplete,
+      onInvalidPlay,
+    );
+
+    expect(onInvalidPlay).toHaveBeenCalledWith(99);
+    expect(animateCard).not.toHaveBeenCalled();
+    expect(onPenaltyComplete).not.toHaveBeenCalled();
+    expect(onNormalComplete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary\nRefactors The Mind scene setup path into smaller helpers and adds focused unit tests for turn-controller animation hook behavior.\n\n## What changed\n- Refactored  into smaller helper methods:\n  - \n  - \n  - \n  - \n  - \n  - \n- Added  and moved audio key constants there.\n- Updated imports in , , and  to use .\n- Added  covering:\n  - valid non-penalty play (animation hook + normal callback)\n  - penalty play (animation hook + penalty callback)\n  - invalid human play (invalid callback, no animation)\n\n## Why\n- Keeps TheMindScene functions concise and easier to maintain/test.\n- Decouples unit-testable gameplay controller logic from UI/Phaser browser globals.\n\n## Validation\n- 
> tableau-card-engine@0.1.0 test
> vitest run --project unit && vitest run --project browser


 RUN  v3.2.4 /home/rgardler/projects/Tableau-Card-Engine

stdout | tests/core-engine/autoSaveTranscript.test.ts > autoSaveTranscript > calls store.save with the correct gameType and transcript
[golf] Transcript saved (golf-001) via golf

 ✓ |unit| tests/ui/discardCard.test.ts (8 tests) 363ms
 ✓ |unit| tests/core-engine/autoSaveTranscript.test.ts (8 tests) 364ms
 ✓ |unit| tests/beleaguered-castle/Integration.test.ts (30 tests) 328ms
 ✓ |unit| tests/main-street/ai-strategy.test.ts (39 tests) 246ms
Game:       main-street
Source:     /home/rgardler/projects/Tableau-Card-Engine/data/screenshots/main-street
Output:     /home/rgardler/projects/Tableau-Card-Engine/public/assets/games/main-street/thumbnail.png
Selected:   /home/rgardler/projects/Tableau-Card-Engine/data/screenshots/main-street/turn-000.png
Thumbnail generated: /home/rgardler/projects/Tableau-Card-Engine/public/assets/games/main-street/thumbnail.png (120x68)
 ✓ |unit| tests/e2e/generate-thumbnail.main-street.test.ts (1 test) 713ms
   ✓ generate-thumbnail script (main-street) > produces a 120x68 thumbnail in public assets  693ms
 ✓ |unit| tests/e2e/main-street-headless.e2e.test.ts (1 test) 819ms
   ✓ Main Street headless demo e2e > runs a short headless Main Street session and validates output  818ms
 ✓ |unit| tests/core-engine/TranscriptStore.test.ts (23 tests) 102ms
 ✓ |unit| tests/ui/placeCard.test.ts (6 tests) 264ms
 ✓ |unit| tests/ui/dealCard.test.ts (6 tests) 213ms
 ✓ |unit| tests/main-street/monte-carlo-greedy-guardrail.test.ts (2 tests) 214ms
 ✓ |unit| tests/the-mind/auto-play.test.ts (33 tests) 76ms
 ✓ |unit| tests/feudalism/AiStrategy.test.ts (14 tests) 56ms
 ✓ |unit| tests/the-mind/integration.test.ts (33 tests) 142ms
 ✓ |unit| tests/main-street/market.integration.test.ts (14 tests) 80ms
 ✓ |unit| tests/lost-cities/lost-cities-ai.test.ts (22 tests) 62ms
 ✓ |unit| tests/golf/Integration.test.ts (19 tests) 83ms
 ✓ |unit| tests/core-engine/SeededRng.test.ts (8 tests) 72ms
 ✓ |unit| tests/golf/GameTranscript.test.ts (14 tests) 122ms
 ✓ |unit| tests/core-engine/SoundManager.test.ts (27 tests) 61ms
 ✓ |unit| tests/core-engine/TranscriptRecorder.test.ts (16 tests) 52ms
 ✓ |unit| tests/main-street/meta-progression.test.ts (94 tests) 98ms
 ✓ |unit| tests/the-mind/ai-strategy.test.ts (70 tests) 41ms
 ✓ |unit| tests/e2e/main-street-transcript.e2e.test.ts (2 tests) 86ms
 ✓ |unit| tests/beleaguered-castle/BeleagueredCastleRules.test.ts (86 tests) 45ms
 ✓ |unit| tests/lost-cities/lost-cities-transcript.test.ts (21 tests) 1919ms
   ✓ Full match transcript > produces a valid transcript for a RandomStrategy AI-vs-AI match  1750ms
 ✓ |unit| tests/ui/GameSelectorScene.test.ts (23 tests) 38ms
 ✓ |unit| tests/the-mind/game-state.test.ts (72 tests) 41ms
 ✓ |unit| tests/main-street/difficulty-presets.test.ts (59 tests) 23ms
 ✓ |unit| tests/replay/adapters.test.ts (72 tests) 38ms
 ✓ |unit| tests/feudalism/FeudalismCards.test.ts (52 tests) 28ms
 ✓ |unit| tests/main-street/save-load.test.ts (5 tests) 18ms
 ✓ |unit| tests/main-street/expanded-card-pool.test.ts (68 tests) 22ms
 ✓ |unit| tests/lost-cities/lost-cities-game.test.ts (40 tests) 35ms
 ✓ |unit| tests/main-street/game-state.test.ts (37 tests) 29ms
 ✓ |unit| tests/main-street/integration.test.ts (24 tests) 39ms
 ✓ |unit| tests/main-street/challenges.test.ts (58 tests) 25ms
 ✓ |unit| tests/main-street/upgrades.test.ts (22 tests) 20ms
 ✓ |unit| tests/main-street/turnflow.test.ts (59 tests) 33ms
 ✓ |unit| tests/ui/shakeIllegalMove.test.ts (15 tests) 12ms
 ✓ |unit| tests/main-street/tfModuleLoader.test.ts (2 tests) 16ms
 ✓ |unit| tests/rule-engine/LegalityResult.test.ts (6 tests) 12ms
 ✓ |unit| tests/feudalism/FeudalismGame.test.ts (56 tests) 26ms
 ✓ |unit| tests/the-mind/mind-card.test.ts (27 tests) 14ms
 ✓ |unit| tests/ui/CardGameScene.test.ts (19 tests) 19ms
 ✓ |unit| tests/golf/AiStrategy.test.ts (20 tests) 28ms
 ✓ |unit| tests/the-mind/transcript.test.ts (32 tests) 24ms
 ✓ |unit| tests/golf/GolfGame.test.ts (14 tests) 20ms
 ✓ |unit| tests/ui/Overlay.test.ts (21 tests) 23ms
 ✓ |unit| tests/main-street/monte-carlo-balance.test.ts (1 test) 14ms
 ✓ |unit| tests/main-street/hint.test.ts (18 tests) 20ms
 ✓ |unit| tests/main-street/activity-log.test.ts (22 tests) 19ms
 ✓ |unit| tests/sushi-go/SushiGoGame.test.ts (21 tests) 11ms
 ✓ |unit| tests/main-street/market.test.ts (33 tests) 30ms
 ✓ |unit| tests/core-engine/SaveLoad.test.ts (9 tests) 19ms
 ✓ |unit| tests/card-system/Deck.test.ts (19 tests) 13ms
 ✓ |unit| tests/core-engine/SoundManager.tf-integration.test.ts (4 tests) 9ms
 ✓ |unit| tests/ui/SceneHeader.test.ts (24 tests) 10ms
 ✓ |unit| tests/ui/SettingsPanel.test.ts (11 tests) 21ms
 ✓ |unit| tests/core-engine/no-runtime-synthesis.test.ts (1 test) 20ms
 ✓ |unit| tests/main-street/adjacency.test.ts (19 tests) 10ms
 ✓ |unit| tests/core-engine/GameEventEmitter.test.ts (50 tests) 17ms
 ✓ |unit| tests/core-engine/SpatialRules.test.ts (7 tests) 15ms
 ✓ |unit| tests/the-mind/mind-card-renderer.test.ts (38 tests) 46ms
 ✓ |unit| tests/golf/GolfGrid.test.ts (19 tests) 44ms
 ✓ |unit| tests/ai/index.test.ts (5 tests) 37ms
 ✓ |unit| tests/ui/createCardGame.test.ts (16 tests) 5ms
 ✓ |unit| tests/card-system/Pile.test.ts (19 tests) 11ms
 ✓ |unit| tests/lost-cities/lost-cities-rules.test.ts (32 tests) 10ms
 ✓ |unit| tests/lost-cities/lost-cities-cards.test.ts (44 tests) 18ms
 ✓ |unit| tests/e2e/replay-main-street.e2e.test.ts (1 test) 4375ms
   ✓ Main Street replay e2e > replays the canonical fixture and captures screenshots without errors  4373ms
 ✓ |unit| tests/ai/AiUtils.test.ts (14 tests) 20ms
 ✓ |unit| tests/ui/PhaseManager.test.ts (21 tests) 19ms
 ✓ |unit| tests/core-engine/TurnSequencer.test.ts (36 tests) 11ms
 ✓ |unit| tests/main-street/reputation-coin-multiplier.test.ts (28 tests) 24ms
 ✓ |unit| tests/ui/layoutCardPositions.test.ts (13 tests) 11ms
 ✓ |unit| tests/ui/flipCard.test.ts (20 tests) 15ms
 ✓ |unit| tests/sushi-go/SushiGoScoring.test.ts (56 tests) 14ms
 ✓ |unit| tests/core-engine/ChallengeSystem.test.ts (24 tests) 19ms
 ✓ |unit| tests/main-street/easy-mode-phase-bug.test.ts (7 tests) 8ms
 ✓ |unit| tests/the-mind/mind-turn-controller.test.ts (3 tests) 9ms
 ✓ |unit| tests/card-system/index.test.ts (7 tests) 6ms
 ✓ |unit| tests/ui/CardTextureHelpers.test.ts (29 tests) 17ms
 ✓ |unit| tests/sushi-go/SushiGoCards.test.ts (19 tests) 11ms
 ✓ |unit| tests/core-engine/setup-options.test.ts (29 tests) 9ms
 ✓ |unit| tests/golf/GolfScoring.test.ts (18 tests) 3ms
 ✓ |unit| tests/core-engine/GameState.test.ts (12 tests) 14ms
 ✓ |unit| tests/core-engine/SvgHelpers.test.ts (5 tests) 5ms
 ✓ |unit| tests/core-engine/PhaserEventBridge.test.ts (13 tests) 14ms
 ✓ |unit| tests/ui/HelpPanel.test.ts (6 tests) 5ms
 ✓ |unit| tests/core-engine/UndoRedoManager.test.ts (24 tests) 10ms
 ✓ |unit| tests/core-engine/tfAdapter.test.ts (5 tests) 12ms
 ✓ |unit| tests/lost-cities/lost-cities-scoring.test.ts (26 tests) 13ms
 ✓ |unit| tests/ui/moveGameObject.test.ts (2 tests) 6ms
 ✓ |unit| tests/golf/GolfRules.test.ts (22 tests) 4ms
 ✓ |unit| tests/sushi-go/AiStrategy.test.ts (15 tests) 16ms
 ✓ |unit| tests/core-engine/DifficultyPresets.test.ts (17 tests) 25ms
 ✓ |unit| tests/ui/sceneTransition.test.ts (3 tests) 10ms
 ✓ |unit| tests/main-street/positive-incident-multiplier.test.ts (2 tests) 3ms
 ✓ |unit| tests/the-mind/mind-renderer.test.ts (1 test) 8ms
 ✓ |unit| tests/sushi-go-icons.test.ts (1 test) 7ms
 ✓ |unit| tests/core-engine/index.test.ts (11 tests) 10ms
 ✓ |unit| tests/ui/popTextOrIcon.test.ts (3 tests) 8ms
 ✓ |unit| tests/card-system/Card.test.ts (5 tests) 3ms
 ✓ |unit| tests/main-street/transcript-recording.test.ts (1 test) 5ms
 ✓ |unit| tests/card-system/rankValue.test.ts (5 tests) 5ms
 ✓ |unit| tests/core-engine/TranscriptTypes.test.ts (9 tests) 3ms
 ✓ |unit| tests/ui/SettingsStore.test.ts (5 tests) 4ms
 ✓ |unit| tests/main-street/tfRuntimeSynthPreset.test.ts (1 test) 2ms
 ✓ |unit| tests/ui/selection.test.ts (2 tests) 3ms
 ✓ |unit| tests/ai/AiStrategy.test.ts (7 tests) 3ms
 ✓ |unit| tests/the-mind/penalty-animation.test.ts (2 tests) 2ms
 ✓ |unit| tests/sushi-go-wasabi.test.ts (2 tests) 3ms
 ✓ |unit| tests/smoke.test.ts (2 tests) 1ms
 ✓ |unit| tests/test-workflow-safety.test.ts (2 tests) 2ms
 ✓ |unit| tests/core-engine/phaserVersionPin.test.ts (1 test) 2ms
 ✓ |unit| tests/main-street/sfxTfMapping.test.ts (1 test) 6ms
 ✓ |unit| tests/replay/replay.test.ts (20 tests | 5 skipped) 10428ms
   ✓ Replay CLI -- transcript validation > should show help text when --help flag is provided  527ms
   ✓ Replay CLI -- transcript validation > should exit with error when transcript file does not exist  582ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for invalid JSON  670ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for wrong transcript version  502ms
   ✓ Replay CLI -- transcript validation > invalid transcript files > should exit with error for missing initialState  543ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at has no value  700ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at is negative  930ms
   ✓ Replay CLI -- --stop-at argument validation > should exit with error when --stop-at is a decimal  666ms
   ✓ Replay CLI -- --stop-at argument validation > should show --stop-at in help text  666ms
   ✓ Replay CLI -- --skip-to argument validation > should exit with error when --skip-to has no value  515ms
   ✓ Replay CLI -- --skip-to argument validation > should exit with error when --skip-to is negative  352ms
   ✓ Replay CLI -- --skip-to argument validation > should exit with error when --skip-to is a decimal  350ms
   ✓ Replay CLI -- --skip-to argument validation > should show --skip-to in help text  353ms
   ✓ Replay CLI -- v1 transcript handling > should reject v1 transcript when --stop-at is used  345ms
   ✓ Replay CLI -- v1 transcript handling > should accept v1 transcript for regular replay (no --stop-at)  2720ms

 Test Files  117 passed (117)
      Tests  2365 passed | 5 skipped (2370)
   Start at  15:20:07
   Duration  10.79s (transform 3.60s, setup 0ms, collect 9.30s, tests 22.82s, environment 17ms, prepare 8.44s)


 RUN  v3.2.4 /home/rgardler/projects/Tableau-Card-Engine

stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should lay out cards without overlapping grids or piles
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should start in waiting-for-draw and allow drawing from stock or discard
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should transition to waiting-for-move after clicking discard pile
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should execute a swap move when clicking a grid card after drawing
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should support full discard-and-flip flow including face-up card rejection
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should execute AI turn after human and update scores correctly
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should not allow clicks during AI turn
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfInteraction.browser.test.ts > GolfScene interaction tests > should complete a full game with multiple turns
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfInteraction.browser.test.ts (8 tests) 31688ms
   ✓ GolfScene interaction tests > should lay out cards without overlapping grids or piles  1334ms
   ✓ GolfScene interaction tests > should start in waiting-for-draw and allow drawing from stock or discard  1342ms
   ✓ GolfScene interaction tests > should transition to waiting-for-move after clicking discard pile  1293ms
   ✓ GolfScene interaction tests > should execute a swap move when clicking a grid card after drawing  2119ms
   ✓ GolfScene interaction tests > should support full discard-and-flip flow including face-up card rejection  2068ms
   ✓ GolfScene interaction tests > should execute AI turn after human and update scores correctly  3984ms
   ✓ GolfScene interaction tests > should not allow clicks during AI turn  1852ms
   ✓ GolfScene interaction tests > should complete a full game with multiple turns  17695ms
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should lay out 8 tableau columns without horizontal overlap
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should keep all cards and foundations within the game viewport
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts > BeleagueredCastleScene layout regression tests > should not overlap foundation slots with tableau columns
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/beleaguered-castle/BeleagueredCastleLayout.browser.test.ts (3 tests) 10508ms
   ✓ BeleagueredCastleScene layout regression tests > should lay out 8 tableau columns without horizontal overlap  3590ms
   ✓ BeleagueredCastleScene layout regression tests > should keep all cards and foundations within the game viewport  3373ms
   ✓ BeleagueredCastleScene layout regression tests > should not overlap foundation slots with tableau columns  3545ms
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > re-renders activity log after scene restart
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > shows new entries for the restarted run
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > exposes major UI containers via scene accessors
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > renders the street as a 2x5 grid
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > keeps major zones non-overlapping at desktop and narrow mobile dimensions
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > keeps major zones non-overlapping at desktop and narrow mobile dimensions
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > loads placeholder texture and renders it without squashing
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > uses DOM SVG rendering for held-event hand slot when DOM renderer is available
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > routes mapped SFX keys to tf-backed adapter when tf module is provided
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)
[MS] onSlotClick: attempting BuyBusiness {
  "cardId": "biz-park-1",
  "coinsBefore": 8,
  "marketBefore": [
    "biz-park-1",
    "biz-diner-0",
    "biz-bakery-0",
    "biz-bookshop-2",
  ],
  "slotIndex": 0,
}
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)
[MS] onEventCardClick: attempting BuyEvent {
  "cardId": "evt-festival-1",
  "coinsBefore": 4,
  "marketBefore": [
    "upg-patisserie-0",
    "upg-bistro-1",
    "evt-festival-1",
  ],
}
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/main-street/MainStreetScene.browser.test.ts > MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)
[MS] onSlotClick: attempting BuyBusiness {
  "cardId": "biz-bookshop-1",
  "coinsBefore": 8,
  "marketBefore": [
    "biz-bookshop-1",
    "biz-park-0",
    "biz-hardware-2",
    "biz-hardware-1",
  ],
  "slotIndex": 0,
}
 ✓ |browser (chromium)| tests/main-street/MainStreetScene.browser.test.ts (9 tests) 11432ms
   ✓ MainStreetScene browser tests > re-renders activity log after scene restart  569ms
   ✓ MainStreetScene browser tests > keeps major zones non-overlapping at desktop and narrow mobile dimensions  784ms
   ✓ MainStreetScene browser tests > loads placeholder texture and renders it without squashing  450ms
   ✓ MainStreetScene browser tests > uses DOM SVG rendering for held-event hand slot when DOM renderer is available  424ms
   ✓ MainStreetScene browser tests > routes mapped SFX keys to tf-backed adapter when tf module is provided  385ms
   ✓ MainStreetScene browser tests > only materializes purchased cards at destination after transfer animation completes (desktop + narrow viewports)  8163ms
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit turn-started on create and expose emitter globally
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-05-11T14-21-23.015Z.json
stdout | tests/golf/GolfEvents.browser.test.ts > GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end
[GolfScene] Transcript saved (golf-1778509282993-bdq81m) via golf
 ✓ |browser (chromium)| tests/golf/GolfEvents.browser.test.ts (2 tests) 9234ms
   ✓ GolfScene event integration > should emit turn-started on create and expose emitter globally  3322ms
   ✓ GolfScene event integration > should emit correct event sequence for human + AI turn cycle and game-ended on end  5912ms
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should show loss overlay buttons that are interactive
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should restart the scene when "Try Again" is clicked via DOM pointer event
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should show win overlay buttons that respond to DOM clicks
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/the-mind/TheMindOverlay.browser.test.ts > The Mind overlay button tests > should have an interactive input blocker at overlay depth
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/the-mind/TheMindOverlay.browser.test.ts (4 tests) 7114ms
   ✓ The Mind overlay button tests > should show loss overlay buttons that are interactive  1768ms
   ✓ The Mind overlay button tests > should restart the scene when "Try Again" is clicked via DOM pointer event  1873ms
   ✓ The Mind overlay button tests > should show win overlay buttons that respond to DOM clicks  1921ms
   ✓ The Mind overlay button tests > should have an interactive input blocker at overlay depth  1552ms
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should render a canvas element inside the game container
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should create the GolfScene as the active scene
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should create 18 card sprites (9 per player grid)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should display text elements for labels, scores, and instructions
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should have interactive stock and discard pile sprites
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfScene.browser.test.ts > GolfScene browser tests > should not have any console errors during initialization
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfScene.browser.test.ts (6 tests) 8766ms
   ✓ GolfScene browser tests > should render a canvas element inside the game container  1517ms
   ✓ GolfScene browser tests > should create the GolfScene as the active scene  1342ms
   ✓ GolfScene browser tests > should create 18 card sprites (9 per player grid)  1420ms
   ✓ GolfScene browser tests > should display text elements for labels, scores, and instructions  1445ms
   ✓ GolfScene browser tests > should have interactive stock and discard pile sprites  1340ms
   ✓ GolfScene browser tests > should not have any console errors during initialization  1704ms
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should show overlay buttons that exist in the scene children list
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
[GolfScene] Transcript saved (golf-1778509302036-ijxiz9) via golf
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-05-11T14-21-42.112Z.json
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-05-11T14-21-44.092Z.json
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event
[GolfScene] Transcript saved (golf-1778509303953-06d44i) via golf
stdout | tests/golf/GolfOverlay.browser.test.ts > Golf overlay button tests > should have an interactive input blocker behind the overlay
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfOverlay.browser.test.ts (3 tests) 5969ms
   ✓ Golf overlay button tests > should show overlay buttons that exist in the scene children list  1902ms
   ✓ Golf overlay button tests > should restart the scene when "Play Again" is clicked via DOM pointer event  2099ms
   ✓ Golf overlay button tests > should have an interactive input blocker behind the overlay  1968ms
[transcript-persist] Saved transcript to /home/rgardler/projects/Tableau-Card-Engine/data/transcripts/golf/golf-2026-05-11T14-21-46.109Z.json
stdout | unknown test
[GolfScene] Transcript saved (golf-1778509306102-grjikb) via golf
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should render a help button ("?") in the scene
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should have the help panel initially closed (not visible)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/ui/HelpPanel.browser.test.ts > HelpPanel browser tests > should not produce console errors with the help panel integrated
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/ui/HelpPanel.browser.test.ts (4 tests) 4545ms
   ✓ HelpPanel browser tests > should render a help button ("?") in the scene  1266ms
   ✓ HelpPanel browser tests > should have the help panel initially closed (not visible)  1322ms
   ✓ HelpPanel browser tests > should not produce console errors with the help panel integrated  1915ms
stdout | tests/golf/GolfReplay.browser.test.ts > GolfScene replay mode > should enter replay mode and support loadBoardState()
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/golf/GolfReplay.browser.test.ts > GolfScene replay mode > should throw if loadBoardState() is called outside replay mode
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/golf/GolfReplay.browser.test.ts (2 tests) 2744ms
   ✓ GolfScene replay mode > should enter replay mode and support loadBoardState()  1515ms
   ✓ GolfScene replay mode > should throw if loadBoardState() is called outside replay mode  1229ms
stdout | tests/main-street/MainStreetSvgSmoke.browser.test.ts > MainStreetScene SVG smoke > renders at least one rasterized SVG card texture that is non-solid
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/main-street/MainStreetSvgSmoke.browser.test.ts (1 test) 1045ms
   ✓ MainStreetScene SVG smoke > renders at least one rasterized SVG card texture that is non-solid  1045ms
stdout | tests/sushi-go/SushiGoIcons.browser.test.ts > SushiGoScene SVG icon rendering > renders sushi icons as non-solid images (not black squares)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/sushi-go/SushiGoIcons.browser.test.ts (1 test) 954ms
   ✓ SushiGoScene SVG icon rendering > renders sushi icons as non-solid images (not black squares)  954ms
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should have non-overlapping upper band sections (patrons, market, supply)
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should not overlap player/AI section boxes with action buttons or instruction text
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
stdout | tests/feudalism/FeudalismLayout.browser.test.ts > FeudalismScene layout regression tests > should not overlap action buttons with instruction text
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/feudalism/FeudalismLayout.browser.test.ts (3 tests) 602ms
   ✓ FeudalismScene layout regression tests > should have non-overlapping upper band sections (patrons, market, supply)  333ms
stdout | tests/the-mind/MindCardRenderer.browser.test.ts > TheMind browser smoke > renders at least one Mind card to the canvas
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/the-mind/MindCardRenderer.browser.test.ts (1 test) 313ms
   ✓ TheMind browser smoke > renders at least one Mind card to the canvas  313ms
stdout | tests/feudalism/FeudalismSelection.browser.test.ts > Feudalism selected market card highlight > persists selected card highlight and clears on non-card click
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/feudalism/FeudalismSelection.browser.test.ts (1 test) 301ms
   ✓ Feudalism selected market card highlight > persists selected card highlight and clears on non-card click  301ms
stdout | tests/hello-world/HelloWorldScene.browser.test.ts > HelloWorldScene browser smoke > boots and renders the HelloWorldScene under Phaser 4
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/hello-world/HelloWorldScene.browser.test.ts (1 test) 110ms
stdout | tests/core-engine/SvgHelpers.browser.test.ts > SvgHelpers (browser integration) > creates a Phaser texture from SVG via getOrCreateTexture
%c %c %c %c %c Phaser v4.0.0 RC7 (WebGL | Web Audio) %c https://phaser.io/v400 background: #ff0000 background: #ffff00 background: #00ff00 background: #00ffff color: #ffffff; background: #000000 background: transparent
 ✓ |browser (chromium)| tests/core-engine/SvgHelpers.browser.test.ts (1 test) 39ms
 ✓ |browser (chromium)| tests/beleaguered-castle/BeleagueredCastleTurnController.browser.test.ts (2 tests) 2ms
 ✓ |browser (chromium)| tests/core-engine/PhaserEventBridge.browser.test.ts (6 tests) 2ms
 ✓ |browser (chromium)| tests/smoke.phaser4.browser.test.ts (2 tests) 2ms

 Test Files  19 passed (19)
      Tests  60 passed (60)
   Start at  15:20:18
   Duration  100.49s (transform 0ms, setup 0ms, collect 2.14s, tests 95.37s, environment 0ms, prepare 1521.31s)\n- 
> tableau-card-engine@0.1.0 build
> tsc --noEmit && vite build

vite v6.4.1 building for production...
transforming...
✓ 172 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                    0.59 kB │ gzip:   0.37 kB
dist/assets/index-edDNZ5rG.js  2,044.69 kB │ gzip: 478.32 kB │ map: 11,883.63 kB
✓ built in 5.99s\n\n## Work item\n- TheMind: Break performPlay and animateCardTowardsPile into helpers (CG-0MP19J6WE005W356)\n- Parent: Long functions: 15+ functions exceed 50 lines (CG-0MM1OPFLF07WCFYP)\n\n## Review focus\n- Verify scene setup behavior is unchanged across normal/replay mode.\n- Verify turn-controller callbacks and animation hooks are still wired correctly in all paths.