### PR TITLE
CG-0MP19JIFF005U3TT: split The Mind headless runGame orchestration

### DIFF
--- a/example-games/the-mind/RunGameOrchestrator.ts
+++ b/example-games/the-mind/RunGameOrchestrator.ts
@@ -1,0 +1,261 @@
+import type { PlayerId, TheMindSession } from './TheMindGameState';
+import { playCard, isGameOver, getPileTopValue } from './TheMindGameState';
+import type { MindAiPlayer } from './AiStrategy';
+import { PROXIMITY_MIN_DELAY, PROXIMITY_THRESHOLD } from './AiStrategy';
+import type { MindTranscript, MindTranscriptRecorder } from './GameTranscript';
+
+export interface PendingPlay {
+  readonly playerId: PlayerId;
+  readonly cardValue: number;
+  readonly fireTime: number;
+}
+
+export interface SimulationStats {
+  totalPlays: number;
+  totalPenalties: number;
+  levelStartTime: number;
+}
+
+export interface HeadlessResultSnapshot {
+  readonly totalPlays: number;
+  readonly totalPenalties: number;
+  readonly outcome: 'win' | 'loss';
+  readonly finalLevel: number;
+  readonly finalLives: number;
+}
+
+export function simulateGame(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  recorder: MindTranscriptRecorder,
+): SimulationStats {
+  const stats: SimulationStats = {
+    totalPlays: 0,
+    totalPenalties: 0,
+    levelStartTime: 0,
+  };
+
+  commitLevelDelays(session, aiPlayers);
+
+  while (!isGameOver(session)) {
+    const completed = runNextSimulationStep(session, aiPlayers, recorder, stats);
+    if (completed) {
+      break;
+    }
+  }
+
+  return stats;
+}
+
+export function runNextSimulationStep(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  recorder: MindTranscriptRecorder,
+  stats: SimulationStats,
+): boolean {
+  const queue = buildPlayQueue(
+    aiPlayers,
+    stats.levelStartTime,
+    getPileTopValue(session),
+  );
+
+  if (queue.length === 0) {
+    return true;
+  }
+
+  const next = queue[0];
+  const timestamp = next.fireTime - stats.levelStartTime;
+  const result = playCard(session, next.playerId, next.cardValue);
+
+  if (!result.success) {
+    aiPlayers[next.playerId].removeCard(next.cardValue);
+    return false;
+  }
+
+  recordSuccessfulPlay(
+    session,
+    aiPlayers,
+    recorder,
+    stats,
+    next,
+    timestamp,
+    result,
+  );
+
+  if (result.levelComplete) {
+    return handleLevelCompletion(
+      session,
+      aiPlayers,
+      recorder,
+      stats,
+      next.fireTime,
+      timestamp,
+      result.bonusLifeAwarded,
+    );
+  }
+
+  return isGameOver(session);
+}
+
+function recordSuccessfulPlay(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  recorder: MindTranscriptRecorder,
+  stats: SimulationStats,
+  next: PendingPlay,
+  timestamp: number,
+  result: ReturnType<typeof playCard>,
+): void {
+  stats.totalPlays += 1;
+
+  recorder.recordCardPlay(
+    timestamp,
+    next.playerId,
+    next.cardValue,
+    getPileTopValue(session),
+    session.pile.size(),
+  );
+
+  aiPlayers[next.playerId].removeCard(next.cardValue);
+
+  if (!result.lifeLost) {
+    return;
+  }
+
+  stats.totalPenalties += 1;
+
+  recorder.recordPenalty(
+    timestamp,
+    session.lives,
+    result.penaltyCards.map((p) => ({
+      playerId: p.playerId,
+      cardValue: p.card.value,
+    })),
+  );
+
+  for (const penaltyCard of result.penaltyCards) {
+    aiPlayers[penaltyCard.playerId].removeCard(penaltyCard.card.value);
+  }
+}
+
+function handleLevelCompletion(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  recorder: MindTranscriptRecorder,
+  stats: SimulationStats,
+  fireTime: number,
+  timestamp: number,
+  bonusLifeAwarded: boolean,
+): boolean {
+  const completedLevel = session.outcome === 'win'
+    ? session.currentLevel
+    : session.currentLevel - 1;
+
+  const handsDealt = isGameOver(session)
+    ? undefined
+    : [
+        session.players[0].hand.map((c) => c.value),
+        session.players[1].hand.map((c) => c.value),
+      ] as [readonly number[], readonly number[]];
+
+  recorder.recordLevelComplete(
+    timestamp,
+    completedLevel,
+    bonusLifeAwarded,
+    session.lives,
+    handsDealt,
+  );
+
+  if (isGameOver(session)) {
+    return true;
+  }
+
+  stats.levelStartTime = fireTime;
+  commitLevelDelays(session, aiPlayers);
+  return false;
+}
+
+export function commitLevelDelays(
+  session: TheMindSession,
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+): void {
+  aiPlayers[0].commitLevel(session.players[0].hand);
+  aiPlayers[1].commitLevel(session.players[1].hand);
+}
+
+export function buildPlayQueue(
+  aiPlayers: [MindAiPlayer, MindAiPlayer],
+  levelStartTime: number,
+  pileTopValue: number,
+): PendingPlay[] {
+  const queue: PendingPlay[] = [];
+
+  for (let p = 0; p < 2; p++) {
+    const playerId = p as PlayerId;
+    const delays = aiPlayers[p].getCardDelays();
+
+    for (const delayEntry of delays) {
+      const fireTime = applyProximityDelay(
+        levelStartTime,
+        delayEntry.delay,
+        delayEntry.card.value,
+        pileTopValue,
+      );
+
+      queue.push({
+        playerId,
+        cardValue: delayEntry.card.value,
+        fireTime,
+      });
+    }
+  }
+
+  queue.sort((a, b) => a.fireTime - b.fireTime || a.cardValue - b.cardValue);
+  return queue;
+}
+
+function applyProximityDelay(
+  levelStartTime: number,
+  rawDelay: number,
+  cardValue: number,
+  pileTopValue: number,
+): number {
+  let fireTime = levelStartTime + Math.max(rawDelay, 0);
+
+  if (
+    pileTopValue > 0 &&
+    cardValue - pileTopValue <= PROXIMITY_THRESHOLD
+  ) {
+    const minFireTime = levelStartTime + PROXIMITY_MIN_DELAY;
+    if (fireTime < minFireTime) {
+      fireTime = minFireTime;
+    }
+  }
+
+  return fireTime;
+}
+
+export function buildResultSnapshot(
+  stats: SimulationStats,
+  session: TheMindSession,
+): HeadlessResultSnapshot {
+  return {
+    totalPlays: stats.totalPlays,
+    totalPenalties: stats.totalPenalties,
+    outcome: session.outcome as 'win' | 'loss',
+    finalLevel: session.currentLevel,
+    finalLives: session.lives,
+  };
+}
+
+export function finalizeTranscript(
+  recorder: MindTranscriptRecorder,
+  snapshot: HeadlessResultSnapshot,
+): MindTranscript {
+  return recorder.finalize(
+    Date.now(),
+    snapshot.outcome,
+    snapshot.finalLevel,
+    snapshot.finalLives,
+  );
+}

--- a/example-games/the-mind/headlessGame.ts
+++ b/example-games/the-mind/headlessGame.ts
@@ -2,32 +2,19 @@
  * headlessGame.ts
  *
  * Headless (no Phaser) game runner for The Mind.
- *
- * Simulates a complete AI-vs-AI game by computing timing delays for
- * both players, then resolving plays in chronological order. Produces
- * a valid MindTranscript identical in structure to interactive games.
- *
- * Usage:
- *   import { runGame } from './headlessGame';
- *   const result = runGame({ seed: 42 });
- *   console.log(result.transcript.results);
- *
- * @module
  */
 
 import { createSeededRng } from '../../src/core-engine/SeededRng';
-import type { PlayerId, TheMindSession } from './TheMindGameState';
-import {
-  setupTheMindGame,
-  playCard,
-  isGameOver,
-  getPileTopValue,
-} from './TheMindGameState';
+import { setupTheMindGame } from './TheMindGameState';
 import { MindAiPlayer } from './AiStrategy';
 import type { MindAiTimingConfig } from './AiStrategy';
-import { PROXIMITY_MIN_DELAY, PROXIMITY_THRESHOLD } from './AiStrategy';
 import { MindTranscriptRecorder } from './GameTranscript';
 import type { MindTranscript, MindInitialState } from './GameTranscript';
+import {
+  buildResultSnapshot,
+  finalizeTranscript,
+  simulateGame,
+} from './RunGameOrchestrator';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,14 +24,9 @@ import type { MindTranscript, MindInitialState } from './GameTranscript';
 export interface HeadlessGameConfig {
   /** Seed for the game RNG (deck shuffling). Defaults to 42. */
   seed?: number;
-  /**
-   * Seed for Player 0's AI timing RNG. Defaults to seed + 1.
-   * Using a different seed from Player 1 ensures independent timing.
-   */
+  /** Seed for Player 0's AI timing RNG. Defaults to seed + 1. */
   player0AiSeed?: number;
-  /**
-   * Seed for Player 1's AI timing RNG. Defaults to seed + 2.
-   */
+  /** Seed for Player 1's AI timing RNG. Defaults to seed + 2. */
   player1AiSeed?: number;
   /** Optional timing config override for both AI players. */
   timingConfig?: Partial<MindAiTimingConfig>;
@@ -54,28 +36,12 @@ export interface HeadlessGameConfig {
 
 /** Result of a headless game run. */
 export interface HeadlessGameResult {
-  /** The finalized transcript. */
   readonly transcript: MindTranscript;
-  /** Total number of card plays across all levels. */
   readonly totalPlays: number;
-  /** Total number of penalties incurred. */
   readonly totalPenalties: number;
-  /** Final game outcome. */
   readonly outcome: 'win' | 'loss';
-  /** Final level reached. */
   readonly finalLevel: number;
-  /** Lives remaining at game end. */
   readonly finalLives: number;
-}
-
-/** A pending card play in the simulation queue. */
-interface PendingPlay {
-  /** Which player will play this card. */
-  readonly playerId: PlayerId;
-  /** The card value to play. */
-  readonly cardValue: number;
-  /** Absolute simulation time (ms) when this play fires. */
-  readonly fireTime: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,35 +50,64 @@ interface PendingPlay {
 
 /**
  * Run a complete headless AI-vs-AI game of The Mind.
- *
- * Both players use the linear timing strategy with independent seeded
- * RNGs. The simulation resolves plays in chronological order by their
- * computed fire times, handling penalties and level transitions.
- *
- * @param config - Optional configuration for seeds, timing, and names.
- * @returns A HeadlessGameResult with the finalized transcript and stats.
  */
 export function runGame(config?: HeadlessGameConfig): HeadlessGameResult {
-  const seed = config?.seed ?? 42;
-  const p0AiSeed = config?.player0AiSeed ?? seed + 1;
-  const p1AiSeed = config?.player1AiSeed ?? seed + 2;
-  const names = config?.playerNames ?? ['AI-0', 'AI-1'];
+  const { seed, p0AiSeed, p1AiSeed, names } = resolveConfig(config);
+  const session = createSession(seed, names);
+  const aiPlayers = createAiPlayers(p0AiSeed, p1AiSeed, config?.timingConfig);
+  const recorder = createRecorder(session, names);
 
-  // Create game session with seeded RNG
-  const gameRng = createSeededRng(seed);
-  const session = setupTheMindGame({
+  const stats = simulateGame(session, aiPlayers, recorder);
+  const snapshot = buildResultSnapshot(stats, session);
+  const transcript = finalizeTranscript(recorder, snapshot);
+
+  return {
+    transcript,
+    ...snapshot,
+  };
+}
+
+function resolveConfig(config?: HeadlessGameConfig): {
+  seed: number;
+  p0AiSeed: number;
+  p1AiSeed: number;
+  names: [string, string];
+} {
+  const seed = config?.seed ?? 42;
+  return {
+    seed,
+    p0AiSeed: config?.player0AiSeed ?? seed + 1,
+    p1AiSeed: config?.player1AiSeed ?? seed + 2,
+    names: config?.playerNames ?? ['AI-0', 'AI-1'],
+  };
+}
+
+function createSession(
+  seed: number,
+  names: [string, string],
+) {
+  return setupTheMindGame({
     playerNames: names,
     isAI: [true, true],
-    rng: gameRng,
+    rng: createSeededRng(seed),
   });
+}
 
-  // Create AI players with independent RNGs
-  const aiPlayers: [MindAiPlayer, MindAiPlayer] = [
-    new MindAiPlayer(undefined, createSeededRng(p0AiSeed), config?.timingConfig),
-    new MindAiPlayer(undefined, createSeededRng(p1AiSeed), config?.timingConfig),
+function createAiPlayers(
+  player0Seed: number,
+  player1Seed: number,
+  timingConfig?: Partial<MindAiTimingConfig>,
+): [MindAiPlayer, MindAiPlayer] {
+  return [
+    new MindAiPlayer(undefined, createSeededRng(player0Seed), timingConfig),
+    new MindAiPlayer(undefined, createSeededRng(player1Seed), timingConfig),
   ];
+}
 
-  // Create transcript recorder
+function createRecorder(
+  session: ReturnType<typeof setupTheMindGame>,
+  names: [string, string],
+): MindTranscriptRecorder {
   const initialState: MindInitialState = {
     playerNames: names,
     isAI: [true, true],
@@ -123,192 +118,6 @@ export function runGame(config?: HeadlessGameConfig): HeadlessGameResult {
       session.players[1].hand.map((c) => c.value),
     ],
   };
-  const recorder = new MindTranscriptRecorder(initialState);
 
-  // Simulation state
-  let totalPlays = 0;
-  let totalPenalties = 0;
-  let levelStartTime = 0;
-
-  // Commit initial level delays
-  commitLevelDelays(session, aiPlayers, levelStartTime);
-
-  // Main simulation loop
-  while (!isGameOver(session)) {
-    // Build queue of pending plays from both players
-    const queue = buildPlayQueue(aiPlayers, levelStartTime, getPileTopValue(session));
-
-    if (queue.length === 0) {
-      // No cards left but game not over — shouldn't happen, but guard
-      break;
-    }
-
-    // Pick the earliest play
-    const next = queue[0];
-    const timestamp = next.fireTime - levelStartTime;
-
-    // Execute the play
-    const result = playCard(session, next.playerId, next.cardValue);
-
-    if (!result.success) {
-      // Card was already removed (e.g., by penalty). Remove from AI and retry.
-      aiPlayers[next.playerId].removeCard(next.cardValue);
-      continue;
-    }
-
-    totalPlays++;
-
-    // Record card play
-    recorder.recordCardPlay(
-      timestamp,
-      next.playerId,
-      next.cardValue,
-      getPileTopValue(session),
-      session.pile.size(),
-    );
-
-    // Remove from both AI players (the played card, and any penalty cards)
-    aiPlayers[next.playerId].removeCard(next.cardValue);
-
-    if (result.lifeLost) {
-      totalPenalties++;
-
-      recorder.recordPenalty(
-        timestamp,
-        session.lives,
-        result.penaltyCards.map((p) => ({
-          playerId: p.playerId,
-          cardValue: p.card.value,
-        })),
-      );
-
-      // Remove penalty cards from AI players
-      for (const pc of result.penaltyCards) {
-        aiPlayers[pc.playerId].removeCard(pc.card.value);
-      }
-    }
-
-    // Handle level completion (must be recorded before game-over check,
-    // since completing the final level triggers both levelComplete and
-    // game-over simultaneously)
-    if (result.levelComplete) {
-      // When the game is won, currentLevel stays at MAX_LEVEL (no dealLevel call).
-      // When a non-final level completes, dealLevel advances currentLevel.
-      const completedLevel = session.outcome === 'win'
-        ? session.currentLevel
-        : session.currentLevel - 1;
-
-      // If the game is not over, dealLevel has already been called and
-      // the session now holds the new hands for the next level.
-      const handsDealt: [readonly number[], readonly number[]] | undefined =
-        !isGameOver(session)
-          ? [
-              session.players[0].hand.map((c) => c.value),
-              session.players[1].hand.map((c) => c.value),
-            ]
-          : undefined;
-
-      recorder.recordLevelComplete(
-        timestamp,
-        completedLevel,
-        result.bonusLifeAwarded,
-        session.lives,
-        handsDealt,
-      );
-
-      if (isGameOver(session)) {
-        break;
-      }
-
-      // New level has been dealt by playCard — commit new delays
-      levelStartTime = next.fireTime;
-      commitLevelDelays(session, aiPlayers, levelStartTime);
-    }
-
-    // Check game over (loss from penalty with no level completion)
-    if (isGameOver(session)) {
-      break;
-    }
-  }
-
-  // Finalize transcript
-  const outcome = session.outcome as 'win' | 'loss';
-  const finalTimestamp = Date.now(); // arbitrary for headless
-  const transcript = recorder.finalize(
-    finalTimestamp,
-    outcome,
-    session.currentLevel,
-    session.lives,
-  );
-
-  return {
-    transcript,
-    totalPlays,
-    totalPenalties,
-    outcome,
-    finalLevel: session.currentLevel,
-    finalLives: session.lives,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Commit level delays for both AI players based on their current hands.
- */
-function commitLevelDelays(
-  session: TheMindSession,
-  aiPlayers: [MindAiPlayer, MindAiPlayer],
-  _levelStartTime: number,
-): void {
-  aiPlayers[0].commitLevel(session.players[0].hand);
-  aiPlayers[1].commitLevel(session.players[1].hand);
-}
-
-/**
- * Build a sorted queue of pending plays from both AI players.
- * Returns plays sorted by fire time (earliest first).
- *
- * When a card is close in value to the pile top (within
- * {@link PROXIMITY_THRESHOLD}), its fire time is raised to at least
- * `levelStartTime + PROXIMITY_MIN_DELAY` so the AI hesitates before
- * playing a card right after a close value.
- */
-function buildPlayQueue(
-  aiPlayers: [MindAiPlayer, MindAiPlayer],
-  levelStartTime: number,
-  pileTopValue: number,
-): PendingPlay[] {
-  const queue: PendingPlay[] = [];
-
-  for (let p = 0; p < 2; p++) {
-    const playerId = p as PlayerId;
-    const delays = aiPlayers[p].getCardDelays();
-    for (const d of delays) {
-      let fireTime = levelStartTime + Math.max(d.delay, 0);
-
-      // Enforce proximity delay for cards close to the pile top
-      if (
-        pileTopValue > 0 &&
-        d.card.value - pileTopValue <= PROXIMITY_THRESHOLD
-      ) {
-        const minFireTime = levelStartTime + PROXIMITY_MIN_DELAY;
-        if (fireTime < minFireTime) {
-          fireTime = minFireTime;
-        }
-      }
-
-      queue.push({
-        playerId,
-        cardValue: d.card.value,
-        fireTime,
-      });
-    }
-  }
-
-  // Sort by fire time, then by card value (lower card first on ties)
-  queue.sort((a, b) => a.fireTime - b.fireTime || a.cardValue - b.cardValue);
-  return queue;
+  return new MindTranscriptRecorder(initialState);
 }

--- a/tests/the-mind/run-game-orchestrator.test.ts
+++ b/tests/the-mind/run-game-orchestrator.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { setupTheMindGame } from '../../example-games/the-mind/TheMindGameState';
+import {
+  buildPlayQueue,
+  buildResultSnapshot,
+  type SimulationStats,
+} from '../../example-games/the-mind/RunGameOrchestrator';
+import { PROXIMITY_MIN_DELAY } from '../../example-games/the-mind/AiStrategy';
+import { createSeededRng } from '../../src/core-engine/SeededRng';
+
+type DelayEntry = { card: { value: number; faceUp: boolean }; delay: number };
+
+function makeAi(delays: DelayEntry[]) {
+  return {
+    getCardDelays: () => delays,
+  };
+}
+
+describe('RunGameOrchestrator.buildPlayQueue', () => {
+  it('sorts by fireTime and then by cardValue', () => {
+    const p0 = makeAi([
+      { card: { value: 40, faceUp: false }, delay: 900 },
+      { card: { value: 20, faceUp: false }, delay: 900 },
+    ]);
+    const p1 = makeAi([
+      { card: { value: 10, faceUp: false }, delay: 800 },
+    ]);
+
+    const queue = buildPlayQueue([p0, p1] as never, 1000, 0);
+
+    expect(queue.map((entry) => entry.cardValue)).toEqual([10, 20, 40]);
+    expect(queue.map((entry) => entry.fireTime)).toEqual([1800, 1900, 1900]);
+  });
+
+  it('enforces minimum proximity delay for cards close to pile top', () => {
+    const p0 = makeAi([{ card: { value: 15, faceUp: false }, delay: 50 }]);
+    const p1 = makeAi([{ card: { value: 90, faceUp: false }, delay: 500 }]);
+
+    const levelStartTime = 200;
+    const queue = buildPlayQueue([p0, p1] as never, levelStartTime, 12);
+
+    const closeCard = queue.find((entry) => entry.cardValue === 15);
+    expect(closeCard).toBeDefined();
+    expect(closeCard?.fireTime).toBe(levelStartTime + PROXIMITY_MIN_DELAY);
+  });
+});
+
+describe('RunGameOrchestrator.buildResultSnapshot', () => {
+  it('aggregates final statistics from simulation and session state', () => {
+    const session = setupTheMindGame({ rng: createSeededRng(11) });
+    session.currentLevel = 6;
+    session.lives = 1;
+    session.outcome = 'loss';
+
+    const stats: SimulationStats = {
+      totalPlays: 42,
+      totalPenalties: 3,
+      levelStartTime: 1234,
+    };
+
+    const snapshot = buildResultSnapshot(stats, session);
+
+    expect(snapshot).toEqual({
+      totalPlays: 42,
+      totalPenalties: 3,
+      outcome: 'loss',
+      finalLevel: 6,
+      finalLives: 1,
+    });
+  });
+});


### PR DESCRIPTION
Summary\nRefactors The Mind headless runner by extracting the simulation loop into a dedicated orchestrator module and leaving runGame as concise orchestration glue.\n\nWhat changed\n- Added example-games/the-mind/RunGameOrchestrator.ts with testable helpers for:\n  - simulation loop\n  - single-step turn execution\n  - play queue construction with proximity-delay behavior\n  - result snapshot and transcript finalization\n- Simplified example-games/the-mind/headlessGame.ts to:\n  - resolve config\n  - create session, AI players, recorder\n  - delegate simulation and final result assembly\n- Added tests/the-mind/run-game-orchestrator.test.ts covering:\n  - queue ordering and tie-break rules\n  - proximity delay enforcement\n  - result snapshot aggregation\n\nValidation\n- npm test\n- npm run build\n\nWork items\n- headlessGame: Split runGame orchestration into smaller units (CG-0MP19JIFF005U3TT)\n- Parent: Long functions: 15+ functions exceed 50 lines (CG-0MM1OPFLF07WCFYP)\n\nReview focus\n- Ensure simulation outcomes remain unchanged for seeded runs.\n- Confirm helper boundaries are clear and no function exceeds 80 lines in the refactored path.