### PR TITLE
CG-0MP19IXJP0037DKD: split Sushi Go tableau refresh into helper-driven layout

### DIFF
--- a/example-games/sushi-go/scenes/SushiGoTableauHelpers.ts
+++ b/example-games/sushi-go/scenes/SushiGoTableauHelpers.ts
@@ -1,0 +1,88 @@
+import type { SushiGoCard, SushiGoCardType } from '../SushiGoCards';
+
+export interface TableauLayoutItem {
+  type: SushiGoCardType;
+  cards: SushiGoCard[];
+  startX: number;
+  width: number;
+}
+
+export interface WasabiPairing {
+  readonly wasabiToNigiri: Map<number, number>;
+  readonly nigiriToWasabi: Map<number, number>;
+}
+
+export function computeEncounterOrder(tableau: SushiGoCard[]): SushiGoCardType[] {
+  const seen = new Set<SushiGoCardType>();
+  const order: SushiGoCardType[] = [];
+
+  for (const card of tableau) {
+    if (seen.has(card.type)) {
+      continue;
+    }
+    seen.add(card.type);
+    order.push(card.type);
+  }
+
+  return order;
+}
+
+export function pairWasabiNigiri(tableau: SushiGoCard[]): WasabiPairing {
+  const wasabiToNigiri = new Map<number, number>();
+  const nigiriToWasabi = new Map<number, number>();
+  const queue: number[] = [];
+
+  for (const card of tableau) {
+    if (card.type === 'wasabi') {
+      queue.push(card.id);
+      continue;
+    }
+
+    if (card.type !== 'nigiri' || queue.length === 0) {
+      continue;
+    }
+
+    const wasabiId = queue.shift()!;
+    wasabiToNigiri.set(wasabiId, card.id);
+    nigiriToWasabi.set(card.id, wasabiId);
+  }
+
+  return { wasabiToNigiri, nigiriToWasabi };
+}
+
+export function computeTableauLayout(
+  order: SushiGoCardType[],
+  groups: Map<SushiGoCardType, SushiGoCard[]>,
+  gameWidth: number,
+  cardWidth: number,
+  cardGap: number,
+  groupGap: number,
+): TableauLayoutItem[] {
+  const prepared = order
+    .map((type) => {
+      const cards = groups.get(type) ?? [];
+      if (cards.length === 0) {
+        return null;
+      }
+
+      const width = cards.length * (cardWidth + cardGap) - cardGap;
+      return { type, cards, width };
+    })
+    .filter((item): item is { type: SushiGoCardType; cards: SushiGoCard[]; width: number } => item !== null);
+
+  const totalWidth = prepared.reduce((sum, item) => sum + item.width, 0)
+    + Math.max(0, prepared.length - 1) * groupGap;
+
+  let cursorX = (gameWidth - totalWidth) / 2;
+
+  return prepared.map((item) => {
+    const layoutItem: TableauLayoutItem = {
+      type: item.type,
+      cards: item.cards,
+      startX: cursorX,
+      width: item.width,
+    };
+    cursorX += item.width + groupGap;
+    return layoutItem;
+  });
+}

--- a/example-games/sushi-go/scenes/SushiGoTableauRenderer.ts
+++ b/example-games/sushi-go/scenes/SushiGoTableauRenderer.ts
@@ -2,7 +2,7 @@
  * SushiGoTableauRenderer -- renders the tableau display for Sushi Go!
  */
 
-import type { SushiGoCardType } from '../SushiGoCards';
+import type { SushiGoCard, SushiGoCardType } from '../SushiGoCards';
 import { scoreTableauBreakdown, countMakiIcons, scoreMaki } from '../SushiGoScoring';
 import type { SushiGoSession } from '../SushiGoGame';
 import {
@@ -12,6 +12,12 @@ import {
 import { GAME_W } from '../../../src/ui';
 import { SushiGoCardFactory } from './SushiGoCardFactory';
 import { SushiGoRenderer } from './SushiGoRenderer';
+import {
+  computeEncounterOrder,
+  computeTableauLayout,
+  pairWasabiNigiri,
+  type TableauLayoutItem,
+} from './SushiGoTableauHelpers';
 
 export class SushiGoTableauRenderer {
   constructor(
@@ -31,170 +37,218 @@ export class SushiGoTableauRenderer {
     const tableau = this.session.players[playerIdx].tableau;
     const baseY = who === 'player' ? PLAYER_TABLEAU_Y : AI_TABLEAU_Y;
 
-    if (tableau.length === 0) {
-      const empty = this.scene.add.text(GAME_W / 2, baseY, '(no cards yet)', {
-        fontSize: '15px',
-        color: '#666666',
-        fontFamily: 'sans-serif',
-      }).setOrigin(0.5);
-      container.add(empty);
+    if (this.renderEmptyTableauIfNeeded(container, tableau, baseY)) {
       return;
     }
 
-    const wasabiToNigiri = new Map<number, number>();
-    const nigiriToWasabi = new Map<number, number>();
-    const wasabiQueue: number[] = [];
-    for (const c of tableau) {
-      if (c.type === 'wasabi') {
-        wasabiQueue.push(c.id);
-      } else if (c.type === 'nigiri') {
-        if (wasabiQueue.length > 0) {
-          const wId = wasabiQueue.shift()!;
-          wasabiToNigiri.set(wId, c.id);
-          nigiriToWasabi.set(c.id, wId);
-        }
-      }
-    }
-
+    const pairings = pairWasabiNigiri(tableau);
     const groups = this.renderer.groupByType(tableau);
+    const visibleGroups = this.filterVisibleGroups(groups, pairings.wasabiToNigiri);
+    const order = computeEncounterOrder(tableau);
+    const layout = computeTableauLayout(
+      order,
+      visibleGroups,
+      GAME_W,
+      TABLEAU_CARD_W,
+      TABLEAU_CARD_GAP,
+      TABLEAU_GROUP_GAP,
+    );
 
-    const allMakiCounts = this.session.players.map((p) => countMakiIcons(p.tableau));
-    const allMakiBonuses = scoreMaki(allMakiCounts);
+    const makiBonuses = scoreMaki(
+      this.session.players.map((p) => countMakiIcons(p.tableau)),
+    );
 
-    const seenTypes = new Set<string>();
-    const typeOrder: string[] = [];
-    for (const c of tableau) {
-      if (!seenTypes.has(c.type)) {
-        seenTypes.add(c.type);
-        typeOrder.push(c.type);
-      }
+    this.renderGroups(who, container, tableau, baseY, layout, makiBonuses[playerIdx] ?? 0);
+    this.addWasabiOverlays(container, pairings.nigiriToWasabi);
+  }
+
+  private renderEmptyTableauIfNeeded(
+    container: Phaser.GameObjects.Container,
+    tableau: SushiGoCard[],
+    baseY: number,
+  ): boolean {
+    if (tableau.length > 0) {
+      return false;
     }
 
-    let totalWidth = 0;
-    const groupWidths: number[] = [];
-    for (const type of typeOrder) {
-      const cards = groups.get(type as SushiGoCardType);
-      if (!cards || cards.length === 0) continue;
-      const w = cards.length * (TABLEAU_CARD_W + TABLEAU_CARD_GAP) - TABLEAU_CARD_GAP;
-      groupWidths.push(w);
-      totalWidth += w;
+    const empty = this.scene.add.text(GAME_W / 2, baseY, '(no cards yet)', {
+      fontSize: '15px',
+      color: '#666666',
+      fontFamily: 'sans-serif',
+    }).setOrigin(0.5);
+    container.add(empty);
+    return true;
+  }
+
+  private filterVisibleGroups(
+    groups: Map<SushiGoCardType, SushiGoCard[]>,
+    wasabiToNigiri: Map<number, number>,
+  ): Map<SushiGoCardType, SushiGoCard[]> {
+    const visible = new Map(groups);
+    const wasabiCards = visible.get('wasabi') ?? [];
+    const unusedWasabi = wasabiCards.filter((card) => !wasabiToNigiri.has(card.id));
+    visible.set('wasabi', unusedWasabi);
+    return visible;
+  }
+
+  private renderGroups(
+    who: 'player' | 'ai',
+    container: Phaser.GameObjects.Container,
+    tableau: SushiGoCard[],
+    baseY: number,
+    layout: TableauLayoutItem[],
+    playerMakiBonus: number,
+  ): void {
+    const breakdown = scoreTableauBreakdown(tableau);
+
+    for (const group of layout) {
+      const labelText = this.buildTypeLabel(group.type, group.cards, breakdown, playerMakiBonus);
+      this.renderGroupLabel(who, container, group, baseY, labelText);
+      this.renderGroupCards(container, group, baseY);
     }
-    totalWidth += (groupWidths.length - 1) * TABLEAU_GROUP_GAP;
+  }
 
-    let curX = (GAME_W - totalWidth) / 2;
+  private buildTypeLabel(
+    type: SushiGoCardType,
+    cards: SushiGoCard[],
+    breakdown: ReturnType<typeof scoreTableauBreakdown>,
+    playerMakiBonus: number,
+  ): string {
+    const defaultLabel = this.renderer.getTypeGroupLabel(type, cards);
 
-    for (const type of typeOrder) {
-      let cards = groups.get(type as SushiGoCardType);
-      if (!cards || cards.length === 0) continue;
-
-      if (type === 'wasabi') {
-        cards = cards.filter((c) => !wasabiToNigiri.has(c.id));
-        if (cards.length === 0) continue;
+    if (type === 'maki') {
+      if (playerMakiBonus !== 0) {
+        return `Maki(${playerMakiBonus >= 0 ? '+' : ''}${playerMakiBonus})`;
       }
-
-      const groupW = cards.length * (TABLEAU_CARD_W + TABLEAU_CARD_GAP) - TABLEAU_CARD_GAP;
-      let labelText = this.renderer.getTypeGroupLabel(type as SushiGoCardType, cards);
-
-      if (type !== 'pudding') {
-        try {
-          const breakdown = scoreTableauBreakdown(tableau);
-          switch (type) {
-            case 'tempura':
-              labelText = `Tmp(${breakdown.tempura})`;
-              break;
-            case 'sashimi':
-              labelText = `Ssh(${breakdown.sashimi})`;
-              break;
-            case 'dumpling':
-              labelText = `Dmp(${breakdown.dumpling})`;
-              break;
-            case 'nigiri':
-              labelText = `Nig(${breakdown.nigiri})`;
-              break;
-            case 'wasabi':
-              labelText = `Wsb(${cards.length})`;
-              break;
-            case 'chopsticks':
-              labelText = `Chp(${breakdown.chopsticks})`;
-              break;
-          }
-        } catch (e) {
-          console.warn('Failed to compute breakdown for tableau labels', e);
-        }
-      }
-
-      if (type === 'maki') {
-        const totalIcons = cards.reduce((sum, c) => sum + (c.type === 'maki' ? c.icons : 0), 0);
-        const playerMakiBonus = allMakiBonuses[playerIdx] ?? 0;
-        if (playerMakiBonus !== 0) {
-          labelText = `Maki(${playerMakiBonus >= 0 ? '+' : ''}${playerMakiBonus})`;
-        } else {
-          labelText = `Maki(${totalIcons})`;
-        }
-      }
-
-      const typeLabel = this.scene.add.text(
-        curX + groupW / 2,
-        baseY - TABLEAU_CARD_H / 2 - 16,
-        labelText,
-        {
-          fontSize: '11px',
-          color: who === 'player' ? '#aaccaa' : '#99aabb',
-          fontFamily: 'sans-serif',
-        },
-      ).setOrigin(0.5);
-      container.add(typeLabel);
-
-      for (let i = 0; i < cards.length; i++) {
-        const x = curX + i * (TABLEAU_CARD_W + TABLEAU_CARD_GAP) + TABLEAU_CARD_W / 2;
-        const cardRect = this.cardFactory.createCardRect(
-          x, baseY, TABLEAU_CARD_W, TABLEAU_CARD_H, cards[i],
-        );
-        container.add(cardRect);
-      }
-
-      curX += groupW + TABLEAU_GROUP_GAP;
+      const totalIcons = cards.reduce((sum, card) => sum + (card.type === 'maki' ? card.icons : 0), 0);
+      return `Maki(${totalIcons})`;
     }
 
-    for (const [nigiriId] of nigiriToWasabi.entries()) {
-      const children = container.getAll();
-      let nigiriContainer: Phaser.GameObjects.Container | null = null;
-      for (const child of children) {
-        if (!(child instanceof Phaser.GameObjects.Container)) continue;
-        const possible = child.getData && child.getData('cardId') === nigiriId;
-        if (possible) {
-          nigiriContainer = child as Phaser.GameObjects.Container;
-          break;
-        }
-      }
+    if (type === 'pudding') {
+      return defaultLabel;
+    }
 
-      if (!nigiriContainer) continue;
-      if (nigiriContainer.getData('wasabiOverlay')) continue;
+    switch (type) {
+      case 'tempura':
+        return `Tmp(${breakdown.tempura})`;
+      case 'sashimi':
+        return `Ssh(${breakdown.sashimi})`;
+      case 'dumpling':
+        return `Dmp(${breakdown.dumpling})`;
+      case 'nigiri':
+        return `Nig(${breakdown.nigiri})`;
+      case 'wasabi':
+        return `Wsb(${cards.length})`;
+      case 'chopsticks':
+        return `Chp(${breakdown.chopsticks})`;
+      default:
+        return defaultLabel;
+    }
+  }
 
-      if (this.scene.textures.exists('icon-wasabi')) {
-        const iconSize = Math.round(TABLEAU_CARD_W * 0.36);
-        const wasabiY = TABLEAU_CARD_H / 2 - 26;
-        const wasabiImg = this.scene.add.image(0, wasabiY, 'icon-wasabi');
-        wasabiImg.setDisplaySize(iconSize, iconSize);
-        wasabiImg.setOrigin(0.5, 1);
-        nigiriContainer.addAt(wasabiImg, 1);
-      }
-
-      const badgeW = 32;
-      const badgeH = 18;
-      const badgeX = TABLEAU_CARD_W / 2 - badgeW / 2 - 6;
-      const badgeY = -TABLEAU_CARD_H / 2 + badgeH / 2 + 6;
-      const badgeBg = this.scene.add.rectangle(badgeX, badgeY, badgeW, badgeH, 0x90EE90, 1);
-      badgeBg.setStrokeStyle(1, 0x336633);
-      badgeBg.setOrigin(0.5);
-      const badgeText = this.scene.add.text(badgeX, badgeY, 'x3', {
-        fontSize: '12px',
-        color: '#1a3a1a',
+  private renderGroupLabel(
+    who: 'player' | 'ai',
+    container: Phaser.GameObjects.Container,
+    group: TableauLayoutItem,
+    baseY: number,
+    labelText: string,
+  ): void {
+    const typeLabel = this.scene.add.text(
+      group.startX + group.width / 2,
+      baseY - TABLEAU_CARD_H / 2 - 16,
+      labelText,
+      {
+        fontSize: '11px',
+        color: who === 'player' ? '#aaccaa' : '#99aabb',
         fontFamily: 'sans-serif',
-      }).setOrigin(0.5);
-      nigiriContainer.add(badgeBg);
-      nigiriContainer.add(badgeText);
+      },
+    ).setOrigin(0.5);
+    container.add(typeLabel);
+  }
+
+  private renderGroupCards(
+    container: Phaser.GameObjects.Container,
+    group: TableauLayoutItem,
+    baseY: number,
+  ): void {
+    for (let i = 0; i < group.cards.length; i++) {
+      const x = group.startX + i * (TABLEAU_CARD_W + TABLEAU_CARD_GAP) + TABLEAU_CARD_W / 2;
+      const cardRect = this.cardFactory.createCardRect(
+        x,
+        baseY,
+        TABLEAU_CARD_W,
+        TABLEAU_CARD_H,
+        group.cards[i],
+      );
+      container.add(cardRect);
+    }
+  }
+
+  private addWasabiOverlays(
+    container: Phaser.GameObjects.Container,
+    nigiriToWasabi: Map<number, number>,
+  ): void {
+    for (const nigiriId of nigiriToWasabi.keys()) {
+      const nigiriContainer = this.findCardContainer(container, nigiriId);
+      if (!nigiriContainer || nigiriContainer.getData('wasabiOverlay')) {
+        continue;
+      }
+
+      this.renderWasabiIcon(nigiriContainer);
+      this.renderMultiplierBadge(nigiriContainer);
       nigiriContainer.setData('wasabiOverlay', true);
     }
+  }
+
+  private findCardContainer(
+    container: Phaser.GameObjects.Container,
+    cardId: number,
+  ): Phaser.GameObjects.Container | null {
+    const children = container.getAll();
+
+    for (const child of children) {
+      if (!(child instanceof Phaser.GameObjects.Container)) {
+        continue;
+      }
+
+      if (child.getData && child.getData('cardId') === cardId) {
+        return child;
+      }
+    }
+
+    return null;
+  }
+
+  private renderWasabiIcon(target: Phaser.GameObjects.Container): void {
+    if (!this.scene.textures.exists('icon-wasabi')) {
+      return;
+    }
+
+    const iconSize = Math.round(TABLEAU_CARD_W * 0.36);
+    const wasabiY = TABLEAU_CARD_H / 2 - 26;
+    const wasabiImg = this.scene.add.image(0, wasabiY, 'icon-wasabi');
+    wasabiImg.setDisplaySize(iconSize, iconSize);
+    wasabiImg.setOrigin(0.5, 1);
+    target.addAt(wasabiImg, 1);
+  }
+
+  private renderMultiplierBadge(target: Phaser.GameObjects.Container): void {
+    const badgeW = 32;
+    const badgeH = 18;
+    const badgeX = TABLEAU_CARD_W / 2 - badgeW / 2 - 6;
+    const badgeY = -TABLEAU_CARD_H / 2 + badgeH / 2 + 6;
+
+    const badgeBg = this.scene.add.rectangle(badgeX, badgeY, badgeW, badgeH, 0x90EE90, 1);
+    badgeBg.setStrokeStyle(1, 0x336633);
+    badgeBg.setOrigin(0.5);
+
+    const badgeText = this.scene.add.text(badgeX, badgeY, 'x3', {
+      fontSize: '12px',
+      color: '#1a3a1a',
+      fontFamily: 'sans-serif',
+    }).setOrigin(0.5);
+
+    target.add(badgeBg);
+    target.add(badgeText);
   }
 }

--- a/tests/sushi-go/tableau.test.ts
+++ b/tests/sushi-go/tableau.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeEncounterOrder,
+  computeTableauLayout,
+  pairWasabiNigiri,
+} from '../../example-games/sushi-go/scenes/SushiGoTableauHelpers';
+import type { SushiGoCard } from '../../example-games/sushi-go/SushiGoCards';
+
+function card(id: number, type: SushiGoCard['type'], icons: 1 | 2 | 3 = 1): SushiGoCard {
+  switch (type) {
+    case 'maki':
+      return { id, type: 'maki', icons };
+    case 'nigiri':
+      return { id, type: 'nigiri', variant: 'salmon' };
+    case 'tempura':
+      return { id, type: 'tempura' };
+    case 'sashimi':
+      return { id, type: 'sashimi' };
+    case 'dumpling':
+      return { id, type: 'dumpling' };
+    case 'wasabi':
+      return { id, type: 'wasabi' };
+    case 'pudding':
+      return { id, type: 'pudding' };
+    case 'chopsticks':
+      return { id, type: 'chopsticks' };
+  }
+}
+
+describe('SushiGoTableauHelpers', () => {
+  it('computes encounter order without duplicates', () => {
+    const tableau = [
+      card(1, 'tempura'),
+      card(2, 'nigiri'),
+      card(3, 'tempura'),
+      card(4, 'maki', 2),
+    ];
+
+    expect(computeEncounterOrder(tableau)).toEqual(['tempura', 'nigiri', 'maki']);
+  });
+
+  it('pairs wasabi with subsequent nigiri in play order', () => {
+    const tableau = [
+      card(1, 'wasabi'),
+      card(2, 'tempura'),
+      card(3, 'nigiri'),
+      card(4, 'wasabi'),
+      card(5, 'nigiri'),
+    ];
+
+    const { wasabiToNigiri, nigiriToWasabi } = pairWasabiNigiri(tableau);
+
+    expect(wasabiToNigiri.get(1)).toBe(3);
+    expect(wasabiToNigiri.get(4)).toBe(5);
+    expect(nigiriToWasabi.get(3)).toBe(1);
+    expect(nigiriToWasabi.get(5)).toBe(4);
+  });
+
+  it('computes centered group layout with progressive x offsets', () => {
+    const groups = new Map([
+      ['tempura', [card(1, 'tempura'), card(2, 'tempura')]],
+      ['nigiri', [card(3, 'nigiri')]],
+    ] as const);
+
+    const layout = computeTableauLayout(
+      ['tempura', 'nigiri'],
+      groups as never,
+      800,
+      80,
+      10,
+      20,
+    );
+
+    expect(layout).toHaveLength(2);
+    expect(layout[0].type).toBe('tempura');
+    expect(layout[1].type).toBe('nigiri');
+    expect(layout[0].startX).toBeLessThan(layout[1].startX);
+    expect(layout[0].width).toBe(170); // 2 * (80 + 10) - 10
+    expect(layout[1].width).toBe(80);  // 1 * (80 + 10) - 10
+  });
+});


### PR DESCRIPTION
Summary\nRefactors Sushi Go tableau rendering into smaller helper functions and adds unit tests for layout and pairing logic.\n\nWhat changed\n- Added example-games/sushi-go/scenes/SushiGoTableauHelpers.ts\n  - computeEncounterOrder\n  - pairWasabiNigiri\n  - computeTableauLayout\n- Refactored SushiGoTableauRenderer.refreshTableau into focused methods:\n  - empty-state rendering\n  - visible-group filtering\n  - label construction\n  - group rendering\n  - wasabi overlay rendering\n- Added tests/sushi-go/tableau.test.ts for helper logic:\n  - encounter order without duplicates\n  - wasabi-to-nigiri pairing\n  - centered group layout offsets\n\nValidation\n- npm test\n- npm run build\n\nWork items\n- SushiGo: Split refreshTableau into helpers (CG-0MP19IXJP0037DKD)\n- Parent: Long functions: 15+ functions exceed 50 lines (CG-0MM1OPFLF07WCFYP)\n\nReview focus\n- Confirm rendered tableau positions and labels are unchanged in-game.\n- Confirm wasabi overlay placement still appears only on paired nigiri.