### PR TITLE
CG-0MP19J2SE003HMGP: extract shared OverlayManager and migrate SushiGo overlays

### DIFF
--- a/example-games/sushi-go/scenes/SushiGoOverlayManager.ts
+++ b/example-games/sushi-go/scenes/SushiGoOverlayManager.ts
@@ -2,7 +2,14 @@
  * SushiGoOverlayManager -- handles round score and game over overlays for Sushi Go!
  */
 
-import { GAME_W, GAME_H, FONT_FAMILY, createOverlayBackground, createOverlayButton, createOverlayMenuButton, dismissOverlay } from '../../../src/ui';
+import {
+  GAME_W,
+  GAME_H,
+  FONT_FAMILY,
+  createOverlayButton,
+  createOverlayMenuButton,
+  OverlayManager,
+} from '../../../src/ui';
 import { scoreTableauBreakdown } from '../SushiGoScoring';
 import type { SushiGoSession, RoundResult } from '../SushiGoGame';
 import { getWinnerIndex } from '../SushiGoGame';
@@ -15,24 +22,28 @@ import { SFX_KEYS } from './SushiGoConstants';
 const transcriptStore = new TranscriptStore();
 
 export class SushiGoOverlayManager {
-  overlayObjects: Phaser.GameObjects.GameObject[] = [];
+  private readonly overlayManager: OverlayManager;
+
+  get overlayObjects(): Phaser.GameObjects.GameObject[] {
+    return this.overlayManager.objects;
+  }
 
   constructor(
     private scene: Phaser.Scene,
     private session: SushiGoSession,
     private gameEvents: GameEventEmitter,
     private soundManager: SoundManager | null,
-  ) {}
+  ) {
+    this.overlayManager = new OverlayManager(scene);
+  }
 
   showRoundScoreOverlay(result: RoundResult, onNextRound: () => void): void {
     this.soundManager?.play(SFX_KEYS.SCORE_REVEAL);
 
-    const overlay = createOverlayBackground(
-      this.scene,
+    const overlay = this.overlayManager.create(
       { depth: 10, alpha: 0.01 },
       { width: 560, height: 460, alpha: 0.9 },
     );
-    this.overlayObjects.push(...overlay.objects);
 
     const roundNum = result.round + 1;
     const human = this.session.players[0];
@@ -57,19 +68,12 @@ export class SushiGoOverlayManager {
       `Total -- You: ${human.totalScore}  AI: ${ai.totalScore}`,
     ];
 
-    const box = overlay.box;
-    const padding = 24;
-    let textY: number;
-    let buttonY: number;
-    if (box) {
-      const boxTop = box.y - (box.height / 2);
-      const boxBottom = box.y + (box.height / 2);
-      textY = boxTop + padding;
-      buttonY = boxBottom - 40;
-    } else {
-      textY = GAME_H / 2 - 230 + 48;
-      buttonY = GAME_H / 2 + 230 - 40;
-    }
+    const { textY, buttonY } = this.resolveOverlayAnchors(overlay.box, {
+      fallbackTextY: GAME_H / 2 - 230 + 48,
+      fallbackButtonY: GAME_H / 2 + 230 - 40,
+      padding: 24,
+      buttonInset: 40,
+    });
 
     const text = this.scene.add
       .text(GAME_W / 2, textY, lines.join('\n'), {
@@ -81,19 +85,22 @@ export class SushiGoOverlayManager {
       })
       .setOrigin(0.5, 0)
       .setDepth(11);
-    this.overlayObjects.push(text);
+    this.overlayManager.add(text);
 
     const btn = createOverlayButton(this.scene, GAME_W / 2, buttonY, '[ Next Round ]');
     btn.on('pointerdown', () => {
       this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      dismissOverlay(this.overlayObjects);
-      this.overlayObjects = [];
+      this.overlayManager.dismiss();
       onNextRound();
     });
-    this.overlayObjects.push(btn);
+    this.overlayManager.add(btn);
   }
 
-  showGameOverOverlay(result: RoundResult, recorder: SushiGoTranscriptRecorder | null, onRestart: () => void): void {
+  showGameOverOverlay(
+    result: RoundResult,
+    recorder: SushiGoTranscriptRecorder | null,
+    onRestart: () => void,
+  ): void {
     this.soundManager?.play(SFX_KEYS.SCORE_REVEAL);
 
     const winnerIdx = getWinnerIndex(this.session);
@@ -108,12 +115,10 @@ export class SushiGoOverlayManager {
       winnerIndex: winnerIdx,
     });
 
-    const overlay = createOverlayBackground(
-      this.scene,
+    const overlay = this.overlayManager.create(
       { depth: 10, alpha: 0.01 },
       { width: 560, height: 520, alpha: 0.9 },
     );
-    this.overlayObjects.push(...overlay.objects);
 
     const winnerText = winnerIdx === 0 ? 'You Win!' : 'AI Wins!';
     const human = this.session.players[0];
@@ -151,22 +156,15 @@ export class SushiGoOverlayManager {
     }
     lines.push('', `Final: You ${human.totalScore} -- AI ${ai.totalScore}`);
 
-    const box = overlay.box;
-    const padding = 24;
-    let gTextY: number;
-    let gButtonY: number;
-    if (box) {
-      const boxTop = box.y - (box.height / 2);
-      const boxBottom = box.y + (box.height / 2);
-      gTextY = boxTop + padding;
-      gButtonY = boxBottom - 48;
-    } else {
-      gTextY = GAME_H / 2 - 260 + 56;
-      gButtonY = GAME_H / 2 + 260 - 48;
-    }
+    const { textY, buttonY } = this.resolveOverlayAnchors(overlay.box, {
+      fallbackTextY: GAME_H / 2 - 260 + 56,
+      fallbackButtonY: GAME_H / 2 + 260 - 48,
+      padding: 24,
+      buttonInset: 48,
+    });
 
     const text = this.scene.add
-      .text(GAME_W / 2, gTextY, lines.join('\n'), {
+      .text(GAME_W / 2, textY, lines.join('\n'), {
         fontSize: '18px',
         color: '#ffffff',
         fontFamily: FONT_FAMILY,
@@ -175,21 +173,44 @@ export class SushiGoOverlayManager {
       })
       .setOrigin(0.5, 0)
       .setDepth(11);
-    this.overlayObjects.push(text);
+    this.overlayManager.add(text);
 
-    const playBtn = createOverlayButton(this.scene, GAME_W / 2 - 80, gButtonY, '[ Play Again ]');
+    const playBtn = createOverlayButton(this.scene, GAME_W / 2 - 80, buttonY, '[ Play Again ]');
     playBtn.on('pointerdown', () => {
       this.soundManager?.play(SFX_KEYS.UI_CLICK);
       onRestart();
     });
-    this.overlayObjects.push(playBtn);
+    this.overlayManager.add(playBtn);
 
-    const menuBtn = createOverlayMenuButton(this.scene, GAME_W / 2 + 80, gButtonY);
-    this.overlayObjects.push(menuBtn);
+    const menuBtn = createOverlayMenuButton(this.scene, GAME_W / 2 + 80, buttonY);
+    this.overlayManager.add(menuBtn);
+  }
+
+  private resolveOverlayAnchors(
+    box: Phaser.GameObjects.Rectangle | null,
+    options: {
+      fallbackTextY: number;
+      fallbackButtonY: number;
+      padding: number;
+      buttonInset: number;
+    },
+  ): { textY: number; buttonY: number } {
+    if (!box) {
+      return {
+        textY: options.fallbackTextY,
+        buttonY: options.fallbackButtonY,
+      };
+    }
+
+    const boxTop = box.y - (box.height / 2);
+    const boxBottom = box.y + (box.height / 2);
+    return {
+      textY: boxTop + options.padding,
+      buttonY: boxBottom - options.buttonInset,
+    };
   }
 
   dismiss(): void {
-    dismissOverlay(this.overlayObjects);
-    this.overlayObjects = [];
+    this.overlayManager.dismiss();
   }
 }

--- a/src/ui/OverlayManager.ts
+++ b/src/ui/OverlayManager.ts
@@ -1,0 +1,40 @@
+/**
+ * OverlayManager -- small helper to manage modal overlay object lifecycles.
+ */
+
+import {
+  createOverlayBackground,
+  dismissOverlay,
+  type OverlayBackgroundOptions,
+  type OverlayBoxOptions,
+  type OverlayResult,
+} from './Overlay';
+
+export class OverlayManager {
+  private _objects: Phaser.GameObjects.GameObject[] = [];
+
+  constructor(private scene: Phaser.Scene) {}
+
+  get objects(): Phaser.GameObjects.GameObject[] {
+    return this._objects;
+  }
+
+  create(
+    options?: OverlayBackgroundOptions,
+    box?: OverlayBoxOptions,
+  ): OverlayResult {
+    this.dismiss();
+    const overlay = createOverlayBackground(this.scene, options, box);
+    this._objects.push(...overlay.objects);
+    return overlay;
+  }
+
+  add(...objects: Phaser.GameObjects.GameObject[]): void {
+    this._objects.push(...objects);
+  }
+
+  dismiss(): void {
+    dismissOverlay(this._objects);
+    this._objects = [];
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -108,6 +108,7 @@ export type {
 } from './Overlay';
 
 export { createOverlayMenuButton } from './MenuButton';
+export { OverlayManager } from './OverlayManager';
 
 // Hi-DPI text rendering (side-effect import for patching)
 export { TEXT_DPR } from './hiDpiText';

--- a/tests/sushi-go/SushiGoOverlay.browser.test.ts
+++ b/tests/sushi-go/SushiGoOverlay.browser.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Phaser from 'phaser';
+import { waitForScene } from '../helpers/waitForScene';
+
+async function bootGame(): Promise<Phaser.Game> {
+  let container = document.getElementById('game-container');
+  if (container) container.remove();
+  container = document.createElement('div');
+  container.id = 'game-container';
+  document.body.appendChild(container);
+
+  const { createSushiGoGame } = await import('../../example-games/sushi-go/createSushiGoGame');
+  const game = createSushiGoGame();
+  await waitForScene(game, 'SushiGoScene');
+  return game;
+}
+
+function destroyGame(game: Phaser.Game | null): void {
+  if (game) game.destroy(true, false);
+  const container = document.getElementById('game-container');
+  if (container) container.remove();
+}
+
+function waitFrames(n: number): Promise<void> {
+  return new Promise((resolve) => {
+    let count = 0;
+    const step = () => {
+      count += 1;
+      if (count >= n) {
+        resolve();
+      } else {
+        requestAnimationFrame(step);
+      }
+    };
+    requestAnimationFrame(step);
+  });
+}
+
+describe('Sushi Go game-over overlay', () => {
+  let game: Phaser.Game | null = null;
+
+  afterEach(() => {
+    destroyGame(game);
+    game = null;
+  });
+
+  it('renders Play Again and Menu buttons when game-over overlay is shown', async () => {
+    game = await bootGame();
+    const scene = game.scene.getScene('SushiGoScene') as any;
+
+    const fakeRoundResult = {
+      round: 2,
+      tableauScores: [9, 8],
+      tableauBreakdowns: [
+        { tempura: 0, sashimi: 0, dumpling: 0, nigiri: 0, chopsticks: 0, puddingCount: 0 },
+        { tempura: 0, sashimi: 0, dumpling: 0, nigiri: 0, chopsticks: 0, puddingCount: 0 },
+      ],
+      makiCounts: [0, 0],
+      makiBonuses: [0, 0],
+      roundScores: [9, 8],
+      puddingCounts: [0, 0],
+      puddingBonuses: [0, 0],
+    };
+
+    scene.overlayManager.showGameOverOverlay(fakeRoundResult, null, () => {
+      scene.scene.restart();
+    });
+
+    await waitFrames(3);
+
+    const texts = scene.children.list.filter(
+      (child: Phaser.GameObjects.GameObject) => child instanceof Phaser.GameObjects.Text,
+    ) as Phaser.GameObjects.Text[];
+
+    const playAgainBtn = texts.find((t) => t.text === '[ Play Again ]');
+    const menuBtn = texts.find((t) => t.text === '[ Menu ]');
+
+    expect(playAgainBtn).toBeDefined();
+    expect(menuBtn).toBeDefined();
+    expect(playAgainBtn!.input?.enabled).toBe(true);
+    expect(menuBtn!.input?.enabled).toBe(true);
+  });
+});

--- a/tests/ui/OverlayManager.test.ts
+++ b/tests/ui/OverlayManager.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { OverlayManager } from '../../src/ui/OverlayManager';
+
+function mockRectangle() {
+  return {
+    y: 200,
+    height: 100,
+    setDepth: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+}
+
+function mockScene() {
+  return {
+    add: {
+      rectangle: vi.fn(() => mockRectangle()),
+    },
+  } as unknown as Phaser.Scene;
+}
+
+describe('OverlayManager', () => {
+  it('creates and tracks overlay objects', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    const overlay = manager.create({ depth: 10 }, { width: 100, height: 80 });
+
+    expect(overlay.objects).toHaveLength(2);
+    expect(manager.objects).toHaveLength(2);
+  });
+
+  it('dismisses existing overlay before creating a new one', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    manager.create({ depth: 10 }, { width: 100, height: 80 });
+    const firstObjects = [...manager.objects] as unknown as Array<{ destroy: ReturnType<typeof vi.fn> }>;
+
+    manager.create({ depth: 10 }, { width: 120, height: 90 });
+
+    for (const obj of firstObjects) {
+      expect(obj.destroy).toHaveBeenCalledTimes(1);
+    }
+    expect(manager.objects).toHaveLength(2);
+  });
+
+  it('dismisses and clears all tracked objects', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    manager.create({ depth: 10 }, { width: 100, height: 80 });
+    const tracked = [...manager.objects] as unknown as Array<{ destroy: ReturnType<typeof vi.fn> }>;
+
+    manager.dismiss();
+
+    expect(manager.objects).toHaveLength(0);
+    for (const obj of tracked) {
+      expect(obj.destroy).toHaveBeenCalledTimes(1);
+    }
+  });
+});


### PR DESCRIPTION
Summary\nExtracts a reusable UI OverlayManager and migrates Sushi Go overlay rendering to use it, keeping existing visuals and behavior.\n\nWhat changed\n- Added  (shared overlay lifecycle helper)\n- Exported OverlayManager from \n- Updated  to delegate overlay object lifecycle to shared manager\n- Added unit tests for the shared manager: \n- Added browser integration test for Sushi Go game-over overlay buttons: \n\nValidation\n- npm test\n- npm run build\n\nWork items\n- SushiGo: Extract GameOver overlay into shared OverlayManager (CG-0MP19J2SE003HMGP)\n- Parent: Long functions: 15+ functions exceed 50 lines (CG-0MM1OPFLF07WCFYP)\n\nReview focus\n- Verify game-over and round-score overlays in Sushi Go remain visually/functionally unchanged.\n- Verify shared OverlayManager API is minimal and reusable for The Mind overlay unification.