### PR TITLE
CG-0MP19JB0U003B5UJ: unify The Mind win/loss overlays via parameterized helper

### DIFF
--- a/example-games/sushi-go/scenes/SushiGoOverlayManager.ts
+++ b/example-games/sushi-go/scenes/SushiGoOverlayManager.ts
@@ -2,7 +2,14 @@
  * SushiGoOverlayManager -- handles round score and game over overlays for Sushi Go!
  */
 
-import { GAME_W, GAME_H, FONT_FAMILY, createOverlayBackground, createOverlayButton, createOverlayMenuButton, dismissOverlay } from '../../../src/ui';
+import {
+  GAME_W,
+  GAME_H,
+  FONT_FAMILY,
+  createOverlayButton,
+  createOverlayMenuButton,
+  OverlayManager,
+} from '../../../src/ui';
 import { scoreTableauBreakdown } from '../SushiGoScoring';
 import type { SushiGoSession, RoundResult } from '../SushiGoGame';
 import { getWinnerIndex } from '../SushiGoGame';
@@ -15,24 +22,28 @@ import { SFX_KEYS } from './SushiGoConstants';
 const transcriptStore = new TranscriptStore();
 
 export class SushiGoOverlayManager {
-  overlayObjects: Phaser.GameObjects.GameObject[] = [];
+  private readonly overlayManager: OverlayManager;
+
+  get overlayObjects(): Phaser.GameObjects.GameObject[] {
+    return this.overlayManager.objects;
+  }
 
   constructor(
     private scene: Phaser.Scene,
     private session: SushiGoSession,
     private gameEvents: GameEventEmitter,
     private soundManager: SoundManager | null,
-  ) {}
+  ) {
+    this.overlayManager = new OverlayManager(scene);
+  }
 
   showRoundScoreOverlay(result: RoundResult, onNextRound: () => void): void {
     this.soundManager?.play(SFX_KEYS.SCORE_REVEAL);
 
-    const overlay = createOverlayBackground(
-      this.scene,
+    const overlay = this.overlayManager.create(
       { depth: 10, alpha: 0.01 },
       { width: 560, height: 460, alpha: 0.9 },
     );
-    this.overlayObjects.push(...overlay.objects);
 
     const roundNum = result.round + 1;
     const human = this.session.players[0];
@@ -57,19 +68,12 @@ export class SushiGoOverlayManager {
       `Total -- You: ${human.totalScore}  AI: ${ai.totalScore}`,
     ];
 
-    const box = overlay.box;
-    const padding = 24;
-    let textY: number;
-    let buttonY: number;
-    if (box) {
-      const boxTop = box.y - (box.height / 2);
-      const boxBottom = box.y + (box.height / 2);
-      textY = boxTop + padding;
-      buttonY = boxBottom - 40;
-    } else {
-      textY = GAME_H / 2 - 230 + 48;
-      buttonY = GAME_H / 2 + 230 - 40;
-    }
+    const { textY, buttonY } = this.resolveOverlayAnchors(overlay.box, {
+      fallbackTextY: GAME_H / 2 - 230 + 48,
+      fallbackButtonY: GAME_H / 2 + 230 - 40,
+      padding: 24,
+      buttonInset: 40,
+    });
 
     const text = this.scene.add
       .text(GAME_W / 2, textY, lines.join('\n'), {
@@ -81,19 +85,22 @@ export class SushiGoOverlayManager {
       })
       .setOrigin(0.5, 0)
       .setDepth(11);
-    this.overlayObjects.push(text);
+    this.overlayManager.add(text);
 
     const btn = createOverlayButton(this.scene, GAME_W / 2, buttonY, '[ Next Round ]');
     btn.on('pointerdown', () => {
       this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      dismissOverlay(this.overlayObjects);
-      this.overlayObjects = [];
+      this.overlayManager.dismiss();
       onNextRound();
     });
-    this.overlayObjects.push(btn);
+    this.overlayManager.add(btn);
   }
 
-  showGameOverOverlay(result: RoundResult, recorder: SushiGoTranscriptRecorder | null, onRestart: () => void): void {
+  showGameOverOverlay(
+    result: RoundResult,
+    recorder: SushiGoTranscriptRecorder | null,
+    onRestart: () => void,
+  ): void {
     this.soundManager?.play(SFX_KEYS.SCORE_REVEAL);
 
     const winnerIdx = getWinnerIndex(this.session);
@@ -108,12 +115,10 @@ export class SushiGoOverlayManager {
       winnerIndex: winnerIdx,
     });
 
-    const overlay = createOverlayBackground(
-      this.scene,
+    const overlay = this.overlayManager.create(
       { depth: 10, alpha: 0.01 },
       { width: 560, height: 520, alpha: 0.9 },
     );
-    this.overlayObjects.push(...overlay.objects);
 
     const winnerText = winnerIdx === 0 ? 'You Win!' : 'AI Wins!';
     const human = this.session.players[0];
@@ -151,22 +156,15 @@ export class SushiGoOverlayManager {
     }
     lines.push('', `Final: You ${human.totalScore} -- AI ${ai.totalScore}`);
 
-    const box = overlay.box;
-    const padding = 24;
-    let gTextY: number;
-    let gButtonY: number;
-    if (box) {
-      const boxTop = box.y - (box.height / 2);
-      const boxBottom = box.y + (box.height / 2);
-      gTextY = boxTop + padding;
-      gButtonY = boxBottom - 48;
-    } else {
-      gTextY = GAME_H / 2 - 260 + 56;
-      gButtonY = GAME_H / 2 + 260 - 48;
-    }
+    const { textY, buttonY } = this.resolveOverlayAnchors(overlay.box, {
+      fallbackTextY: GAME_H / 2 - 260 + 56,
+      fallbackButtonY: GAME_H / 2 + 260 - 48,
+      padding: 24,
+      buttonInset: 48,
+    });
 
     const text = this.scene.add
-      .text(GAME_W / 2, gTextY, lines.join('\n'), {
+      .text(GAME_W / 2, textY, lines.join('\n'), {
         fontSize: '18px',
         color: '#ffffff',
         fontFamily: FONT_FAMILY,
@@ -175,21 +173,44 @@ export class SushiGoOverlayManager {
       })
       .setOrigin(0.5, 0)
       .setDepth(11);
-    this.overlayObjects.push(text);
+    this.overlayManager.add(text);
 
-    const playBtn = createOverlayButton(this.scene, GAME_W / 2 - 80, gButtonY, '[ Play Again ]');
+    const playBtn = createOverlayButton(this.scene, GAME_W / 2 - 80, buttonY, '[ Play Again ]');
     playBtn.on('pointerdown', () => {
       this.soundManager?.play(SFX_KEYS.UI_CLICK);
       onRestart();
     });
-    this.overlayObjects.push(playBtn);
+    this.overlayManager.add(playBtn);
 
-    const menuBtn = createOverlayMenuButton(this.scene, GAME_W / 2 + 80, gButtonY);
-    this.overlayObjects.push(menuBtn);
+    const menuBtn = createOverlayMenuButton(this.scene, GAME_W / 2 + 80, buttonY);
+    this.overlayManager.add(menuBtn);
+  }
+
+  private resolveOverlayAnchors(
+    box: Phaser.GameObjects.Rectangle | null,
+    options: {
+      fallbackTextY: number;
+      fallbackButtonY: number;
+      padding: number;
+      buttonInset: number;
+    },
+  ): { textY: number; buttonY: number } {
+    if (!box) {
+      return {
+        textY: options.fallbackTextY,
+        buttonY: options.fallbackButtonY,
+      };
+    }
+
+    const boxTop = box.y - (box.height / 2);
+    const boxBottom = box.y + (box.height / 2);
+    return {
+      textY: boxTop + options.padding,
+      buttonY: boxBottom - options.buttonInset,
+    };
   }
 
   dismiss(): void {
-    dismissOverlay(this.overlayObjects);
-    this.overlayObjects = [];
+    this.overlayManager.dismiss();
   }
 }

--- a/example-games/the-mind/scenes/MindOverlayManager.ts
+++ b/example-games/the-mind/scenes/MindOverlayManager.ts
@@ -2,7 +2,12 @@
  * MindOverlayManager -- handles win/loss overlays for The Mind.
  */
 
-import { GAME_W, GAME_H, FONT_FAMILY, createOverlayBackground, createOverlayButton } from '../../../src/ui';
+import {
+  GAME_H,
+  GAME_W,
+  createParameterizedOverlay,
+  overlayCenterY,
+} from '../../../src/ui';
 import { MAX_LEVEL } from '../TheMindGameState';
 import type { TheMindSession } from '../TheMindGameState';
 import type { SoundManager, GameEventEmitter } from '../../../src/core-engine';
@@ -19,165 +24,87 @@ export class MindOverlayManager {
     private soundManager: SoundManager | null,
   ) {}
 
-  // ── Win overlay ────────────────────────────────────────
-
   showWinOverlay(): void {
     this.soundManager?.play(SFX_KEYS.GAME_WIN);
-
-    const overlay = createOverlayBackground(
-      this.scene,
-      { depth: DEPTH_OVERLAY, alpha: 0.75 },
-      { width: 460, height: 280, alpha: 0.9 },
-    );
-    this.overlayObjects.push(...overlay.objects);
-
-    const titleText = this.scene.add
-      .text(GAME_W / 2, GAME_H / 2 - 60, 'You Win!', {
-        fontSize: '36px',
-        color: '#88ff88',
-        fontFamily: FONT_FAMILY,
-        align: 'center',
-      })
-      .setOrigin(0.5)
-      .setDepth(DEPTH_OVERLAY_CONTENT);
-    this.overlayObjects.push(titleText);
-
-    const detailText = this.scene.add
-      .text(
-        GAME_W / 2,
-        GAME_H / 2 - 15,
-        `Completed all ${MAX_LEVEL} levels!\nLives remaining: ${'\u2764'.repeat(this.session.lives)}`,
-        {
-          fontSize: '16px',
-          color: '#cccccc',
-          fontFamily: FONT_FAMILY,
-          align: 'center',
-        },
-      )
-      .setOrigin(0.5)
-      .setDepth(DEPTH_OVERLAY_CONTENT);
-    this.overlayObjects.push(detailText);
-
-    const playAgainBtn = createOverlayButton(
-      this.scene,
-      GAME_W / 2 - 90,
-      GAME_H / 2 + 60,
-      '[ Play Again ]',
-      DEPTH_OVERLAY_CONTENT,
-      { fontSize: '18px' },
-    );
-    playAgainBtn.on('pointerdown', () => {
-      this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      this.gameEvents.emit('ui-interaction', {
-        elementId: 'play-again',
-        action: 'click',
-      });
-      this.scene.time.delayedCall(0, () => this.scene.scene.restart());
+    this.showOutcomeOverlay({
+      title: 'You Win!',
+      titleColor: '#88ff88',
+      detailText: `Completed all ${MAX_LEVEL} levels!\nLives remaining: ${'❤'.repeat(this.session.lives)}`,
+      primaryButtonLabel: '[ Play Again ]',
+      primaryButtonEvent: 'play-again',
     });
-    this.overlayObjects.push(playAgainBtn);
-
-    const menuBtn = createOverlayButton(
-      this.scene,
-      GAME_W / 2 + 90,
-      GAME_H / 2 + 60,
-      '[ Menu ]',
-      DEPTH_OVERLAY_CONTENT,
-      { fontSize: '18px' },
-    );
-    menuBtn.on('pointerdown', () => {
-      this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      this.gameEvents.emit('ui-interaction', {
-        elementId: 'menu',
-        action: 'click',
-      });
-      this.scene.time.delayedCall(0, () =>
-        this.scene.scene.start('GameSelectorScene'),
-      );
-    });
-    this.overlayObjects.push(menuBtn);
   }
-
-  // ── Loss overlay ───────────────────────────────────────
 
   showLossOverlay(): void {
     this.soundManager?.play(SFX_KEYS.GAME_LOST);
+    this.showOutcomeOverlay({
+      title: 'Game Over',
+      titleColor: '#ff6666',
+      detailText: `Reached Level ${this.session.currentLevel} of ${MAX_LEVEL}\nRan out of lives!`,
+      primaryButtonLabel: '[ Try Again ]',
+      primaryButtonEvent: 'try-again',
+    });
+  }
 
-    const overlay = createOverlayBackground(
-      this.scene,
-      { depth: DEPTH_OVERLAY, alpha: 0.75 },
-      { width: 460, height: 280, alpha: 0.9 },
-    );
-    this.overlayObjects.push(...overlay.objects);
+  private showOutcomeOverlay(config: {
+    title: string;
+    titleColor: string;
+    detailText: string;
+    primaryButtonLabel: string;
+    primaryButtonEvent: string;
+  }): void {
+    this.dismiss();
 
-    const titleText = this.scene.add
-      .text(GAME_W / 2, GAME_H / 2 - 60, 'Game Over', {
-        fontSize: '36px',
-        color: '#ff6666',
-        fontFamily: FONT_FAMILY,
-        align: 'center',
-      })
-      .setOrigin(0.5)
-      .setDepth(DEPTH_OVERLAY_CONTENT);
-    this.overlayObjects.push(titleText);
-
-    const detailText = this.scene.add
-      .text(
-        GAME_W / 2,
-        GAME_H / 2 - 15,
-        `Reached Level ${this.session.currentLevel} of ${MAX_LEVEL}\nRan out of lives!`,
+    this.overlayObjects = createParameterizedOverlay(this.scene, {
+      title: config.title,
+      titleColor: config.titleColor,
+      detailText: config.detailText,
+      titleY: overlayCenterY(-60),
+      detailY: overlayCenterY(-15),
+      titleDepth: DEPTH_OVERLAY_CONTENT,
+      detailDepth: DEPTH_OVERLAY_CONTENT,
+      background: { depth: DEPTH_OVERLAY, alpha: 0.75 },
+      box: { width: 460, height: 280, alpha: 0.9 },
+      buttons: [
         {
-          fontSize: '16px',
-          color: '#cccccc',
-          fontFamily: FONT_FAMILY,
-          align: 'center',
+          label: config.primaryButtonLabel,
+          x: GAME_W / 2 - 90,
+          y: GAME_H / 2 + 60,
+          config: { fontSize: '18px' },
+          onClick: () => {
+            this.soundManager?.play(SFX_KEYS.UI_CLICK);
+            this.gameEvents.emit('ui-interaction', {
+              elementId: config.primaryButtonEvent,
+              action: 'click',
+            });
+            this.scene.time.delayedCall(0, () => this.scene.scene.restart());
+          },
         },
-      )
-      .setOrigin(0.5)
-      .setDepth(DEPTH_OVERLAY_CONTENT);
-    this.overlayObjects.push(detailText);
-
-    const tryAgainBtn = createOverlayButton(
-      this.scene,
-      GAME_W / 2 - 90,
-      GAME_H / 2 + 60,
-      '[ Try Again ]',
-      DEPTH_OVERLAY_CONTENT,
-      { fontSize: '18px' },
-    );
-    tryAgainBtn.on('pointerdown', () => {
-      this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      this.gameEvents.emit('ui-interaction', {
-        elementId: 'try-again',
-        action: 'click',
-      });
-      this.scene.time.delayedCall(0, () => this.scene.scene.restart());
+        {
+          label: '[ Menu ]',
+          x: GAME_W / 2 + 90,
+          y: GAME_H / 2 + 60,
+          config: { fontSize: '18px' },
+          onClick: () => {
+            this.soundManager?.play(SFX_KEYS.UI_CLICK);
+            this.gameEvents.emit('ui-interaction', {
+              elementId: 'menu',
+              action: 'click',
+            });
+            this.scene.time.delayedCall(0, () =>
+              this.scene.scene.start('GameSelectorScene'),
+            );
+          },
+        },
+      ],
     });
-    this.overlayObjects.push(tryAgainBtn);
-
-    const menuBtn = createOverlayButton(
-      this.scene,
-      GAME_W / 2 + 90,
-      GAME_H / 2 + 60,
-      '[ Menu ]',
-      DEPTH_OVERLAY_CONTENT,
-      { fontSize: '18px' },
-    );
-    menuBtn.on('pointerdown', () => {
-      this.soundManager?.play(SFX_KEYS.UI_CLICK);
-      this.gameEvents.emit('ui-interaction', {
-        elementId: 'menu',
-        action: 'click',
-      });
-      this.scene.time.delayedCall(0, () =>
-        this.scene.scene.start('GameSelectorScene'),
-      );
-    });
-    this.overlayObjects.push(menuBtn);
   }
 
   dismiss(): void {
     for (const obj of this.overlayObjects) {
-      if (obj.active) obj.destroy();
+      if (obj.active) {
+        obj.destroy();
+      }
     }
     this.overlayObjects = [];
   }

--- a/src/ui/OverlayManager.ts
+++ b/src/ui/OverlayManager.ts
@@ -1,0 +1,40 @@
+/**
+ * OverlayManager -- small helper to manage modal overlay object lifecycles.
+ */
+
+import {
+  createOverlayBackground,
+  dismissOverlay,
+  type OverlayBackgroundOptions,
+  type OverlayBoxOptions,
+  type OverlayResult,
+} from './Overlay';
+
+export class OverlayManager {
+  private _objects: Phaser.GameObjects.GameObject[] = [];
+
+  constructor(private scene: Phaser.Scene) {}
+
+  get objects(): Phaser.GameObjects.GameObject[] {
+    return this._objects;
+  }
+
+  create(
+    options?: OverlayBackgroundOptions,
+    box?: OverlayBoxOptions,
+  ): OverlayResult {
+    this.dismiss();
+    const overlay = createOverlayBackground(this.scene, options, box);
+    this._objects.push(...overlay.objects);
+    return overlay;
+  }
+
+  add(...objects: Phaser.GameObjects.GameObject[]): void {
+    this._objects.push(...objects);
+  }
+
+  dismiss(): void {
+    dismissOverlay(this._objects);
+    this._objects = [];
+  }
+}

--- a/src/ui/ParameterizedOverlay.ts
+++ b/src/ui/ParameterizedOverlay.ts
@@ -1,0 +1,81 @@
+import { FONT_FAMILY, GAME_H, GAME_W } from './constants';
+import { createOverlayBackground, type OverlayBackgroundOptions, type OverlayBoxOptions } from './Overlay';
+import { createOverlayButton, type OverlayButtonConfig } from './OverlayButton';
+
+export interface ParameterizedOverlayButton {
+  readonly label: string;
+  readonly x: number;
+  readonly y: number;
+  readonly onClick: () => void;
+  readonly config?: OverlayButtonConfig;
+}
+
+export interface ParameterizedOverlayConfig {
+  readonly title: string;
+  readonly titleColor: string;
+  readonly detailText: string;
+  readonly detailColor?: string;
+  readonly titleY: number;
+  readonly detailY: number;
+  readonly titleFontSize?: string;
+  readonly detailFontSize?: string;
+  readonly titleDepth: number;
+  readonly detailDepth: number;
+  readonly buttons: ReadonlyArray<ParameterizedOverlayButton>;
+  readonly background?: OverlayBackgroundOptions;
+  readonly box?: OverlayBoxOptions;
+}
+
+export function createParameterizedOverlay(
+  scene: Phaser.Scene,
+  config: ParameterizedOverlayConfig,
+): Phaser.GameObjects.GameObject[] {
+  const overlay = createOverlayBackground(
+    scene,
+    config.background,
+    config.box,
+  );
+
+  const objects: Phaser.GameObjects.GameObject[] = [...overlay.objects];
+
+  const title = scene.add
+    .text(GAME_W / 2, config.titleY, config.title, {
+      fontSize: config.titleFontSize ?? '36px',
+      color: config.titleColor,
+      fontFamily: FONT_FAMILY,
+      align: 'center',
+    })
+    .setOrigin(0.5)
+    .setDepth(config.titleDepth);
+  objects.push(title);
+
+  const detail = scene.add
+    .text(GAME_W / 2, config.detailY, config.detailText, {
+      fontSize: config.detailFontSize ?? '16px',
+      color: config.detailColor ?? '#cccccc',
+      fontFamily: FONT_FAMILY,
+      align: 'center',
+    })
+    .setOrigin(0.5)
+    .setDepth(config.detailDepth);
+  objects.push(detail);
+
+  for (const button of config.buttons) {
+    const btn = createOverlayButton(
+      scene,
+      button.x,
+      button.y,
+      button.label,
+      config.detailDepth,
+      button.config,
+    );
+    btn.on('pointerdown', button.onClick);
+    objects.push(btn);
+  }
+
+  return objects;
+}
+
+export function overlayCenterY(offset: number): number {
+  return GAME_H / 2 + offset;
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -109,6 +109,14 @@ export type {
 
 export { createOverlayMenuButton } from './MenuButton';
 export { OverlayManager } from './OverlayManager';
+export {
+  createParameterizedOverlay,
+  overlayCenterY,
+} from './ParameterizedOverlay';
+export type {
+  ParameterizedOverlayConfig,
+  ParameterizedOverlayButton,
+} from './ParameterizedOverlay';
 
 // Hi-DPI text rendering (side-effect import for patching)
 export { TEXT_DPR } from './hiDpiText';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -108,6 +108,7 @@ export type {
 } from './Overlay';
 
 export { createOverlayMenuButton } from './MenuButton';
+export { OverlayManager } from './OverlayManager';
 
 // Hi-DPI text rendering (side-effect import for patching)
 export { TEXT_DPR } from './hiDpiText';

--- a/tests/sushi-go/SushiGoOverlay.browser.test.ts
+++ b/tests/sushi-go/SushiGoOverlay.browser.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Phaser from 'phaser';
+import { waitForScene } from '../helpers/waitForScene';
+
+async function bootGame(): Promise<Phaser.Game> {
+  let container = document.getElementById('game-container');
+  if (container) container.remove();
+  container = document.createElement('div');
+  container.id = 'game-container';
+  document.body.appendChild(container);
+
+  const { createSushiGoGame } = await import('../../example-games/sushi-go/createSushiGoGame');
+  const game = createSushiGoGame();
+  await waitForScene(game, 'SushiGoScene');
+  return game;
+}
+
+function destroyGame(game: Phaser.Game | null): void {
+  if (game) game.destroy(true, false);
+  const container = document.getElementById('game-container');
+  if (container) container.remove();
+}
+
+function waitFrames(n: number): Promise<void> {
+  return new Promise((resolve) => {
+    let count = 0;
+    const step = () => {
+      count += 1;
+      if (count >= n) {
+        resolve();
+      } else {
+        requestAnimationFrame(step);
+      }
+    };
+    requestAnimationFrame(step);
+  });
+}
+
+describe('Sushi Go game-over overlay', () => {
+  let game: Phaser.Game | null = null;
+
+  afterEach(() => {
+    destroyGame(game);
+    game = null;
+  });
+
+  it('renders Play Again and Menu buttons when game-over overlay is shown', async () => {
+    game = await bootGame();
+    const scene = game.scene.getScene('SushiGoScene') as any;
+
+    const fakeRoundResult = {
+      round: 2,
+      tableauScores: [9, 8],
+      tableauBreakdowns: [
+        { tempura: 0, sashimi: 0, dumpling: 0, nigiri: 0, chopsticks: 0, puddingCount: 0 },
+        { tempura: 0, sashimi: 0, dumpling: 0, nigiri: 0, chopsticks: 0, puddingCount: 0 },
+      ],
+      makiCounts: [0, 0],
+      makiBonuses: [0, 0],
+      roundScores: [9, 8],
+      puddingCounts: [0, 0],
+      puddingBonuses: [0, 0],
+    };
+
+    scene.overlayManager.showGameOverOverlay(fakeRoundResult, null, () => {
+      scene.scene.restart();
+    });
+
+    await waitFrames(3);
+
+    const texts = scene.children.list.filter(
+      (child: Phaser.GameObjects.GameObject) => child instanceof Phaser.GameObjects.Text,
+    ) as Phaser.GameObjects.Text[];
+
+    const playAgainBtn = texts.find((t) => t.text === '[ Play Again ]');
+    const menuBtn = texts.find((t) => t.text === '[ Menu ]');
+
+    expect(playAgainBtn).toBeDefined();
+    expect(menuBtn).toBeDefined();
+    expect(playAgainBtn!.input?.enabled).toBe(true);
+    expect(menuBtn!.input?.enabled).toBe(true);
+  });
+});

--- a/tests/ui/OverlayManager.test.ts
+++ b/tests/ui/OverlayManager.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { OverlayManager } from '../../src/ui/OverlayManager';
+
+function mockRectangle() {
+  return {
+    y: 200,
+    height: 100,
+    setDepth: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+}
+
+function mockScene() {
+  return {
+    add: {
+      rectangle: vi.fn(() => mockRectangle()),
+    },
+  } as unknown as Phaser.Scene;
+}
+
+describe('OverlayManager', () => {
+  it('creates and tracks overlay objects', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    const overlay = manager.create({ depth: 10 }, { width: 100, height: 80 });
+
+    expect(overlay.objects).toHaveLength(2);
+    expect(manager.objects).toHaveLength(2);
+  });
+
+  it('dismisses existing overlay before creating a new one', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    manager.create({ depth: 10 }, { width: 100, height: 80 });
+    const firstObjects = [...manager.objects] as unknown as Array<{ destroy: ReturnType<typeof vi.fn> }>;
+
+    manager.create({ depth: 10 }, { width: 120, height: 90 });
+
+    for (const obj of firstObjects) {
+      expect(obj.destroy).toHaveBeenCalledTimes(1);
+    }
+    expect(manager.objects).toHaveLength(2);
+  });
+
+  it('dismisses and clears all tracked objects', () => {
+    const scene = mockScene();
+    const manager = new OverlayManager(scene);
+
+    manager.create({ depth: 10 }, { width: 100, height: 80 });
+    const tracked = [...manager.objects] as unknown as Array<{ destroy: ReturnType<typeof vi.fn> }>;
+
+    manager.dismiss();
+
+    expect(manager.objects).toHaveLength(0);
+    for (const obj of tracked) {
+      expect(obj.destroy).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/tests/ui/ParameterizedOverlay.test.ts
+++ b/tests/ui/ParameterizedOverlay.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createParameterizedOverlay, overlayCenterY } from '../../src/ui/ParameterizedOverlay';
+
+function mockRectangle() {
+  return {
+    setDepth: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+}
+
+function mockText() {
+  const handlers: Record<string, () => void> = {};
+  const text = {
+    setOrigin: vi.fn().mockReturnThis(),
+    setDepth: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    setColor: vi.fn().mockReturnThis(),
+    on: vi.fn((event: string, handler: () => void) => {
+      handlers[event] = handler;
+      return text;
+    }),
+    destroy: vi.fn(),
+    _handlers: handlers,
+  };
+  return text;
+}
+
+function mockScene() {
+  return {
+    add: {
+      rectangle: vi.fn(() => mockRectangle()),
+      text: vi.fn(() => mockText()),
+    },
+  } as unknown as Phaser.Scene;
+}
+
+describe('createParameterizedOverlay', () => {
+  it('creates background, title, details and button objects', () => {
+    const scene = mockScene();
+    const clicked = vi.fn();
+
+    const objects = createParameterizedOverlay(scene, {
+      title: 'You Win!',
+      titleColor: '#88ff88',
+      detailText: 'Details',
+      titleY: 200,
+      detailY: 230,
+      titleDepth: 12,
+      detailDepth: 12,
+      background: { depth: 10, alpha: 0.75 },
+      box: { width: 400, height: 240, alpha: 0.9 },
+      buttons: [
+        {
+          label: '[ Play Again ]',
+          x: 300,
+          y: 320,
+          onClick: clicked,
+        },
+      ],
+    });
+
+    expect(objects.length).toBeGreaterThanOrEqual(5);
+
+    const button = objects[objects.length - 1] as any;
+    expect(button.on).toHaveBeenCalledWith('pointerdown', expect.any(Function));
+
+    const handlers = button._handlers;
+    handlers.pointerdown();
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('computes center offset helper from game center', () => {
+    expect(overlayCenterY(0)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Summary\nUnifies The Mind win/loss overlays by introducing a parameterized overlay utility and routing both outcomes through one shared overlay construction path.\n\nWhat changed\n- Added src/ui/ParameterizedOverlay.ts with:\n  - createParameterizedOverlay\n  - overlayCenterY\n- Exported the new utility from src/ui/index.ts\n- Refactored example-games/the-mind/scenes/MindOverlayManager.ts:\n  - showWinOverlay and showLossOverlay now delegate to showOutcomeOverlay\n  - duplicated title/detail/button creation removed\n- Added unit tests: tests/ui/ParameterizedOverlay.test.ts\n\nValidation\n- npm test\n- npm run build\n\nWork items\n- TheMind: Unify win/loss overlays into parameterized overlay (CG-0MP19JB0U003B5UJ)\n- Parent: Long functions: 15+ functions exceed 50 lines (CG-0MM1OPFLF07WCFYP)\n\nReview focus\n- Confirm win/loss overlays are visually and behaviorally unchanged in The Mind.\n- Confirm button callbacks (restart/menu) still emit interactions and navigate correctly.