### PR TITLE
CG-0MP1QYJ830004WNF: add baseline catalog verification

### DIFF
--- a/docs/main-street/card-catalog-baseline.json
+++ b/docs/main-street/card-catalog-baseline.json
@@ -1,0 +1,16 @@
+{
+  "source": "Tier 1 baseline from example-games/main-street/MainStreetTiers.ts",
+  "capturedAt": "2026-05-11T23:24:23.737Z",
+  "perTier": {
+    "tier1": {
+      "business": 5,
+      "event": 5,
+      "upgrade": 3,
+      "total": 13
+    }
+  },
+  "totals": {
+    "baselineTotal": 13,
+    "targetAtLeast": 26
+  }
+}

--- a/scripts/generate-main-street-catalog-baseline.ts
+++ b/scripts/generate-main-street-catalog-baseline.ts
@@ -1,0 +1,44 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { TIER_DEFINITIONS } from '../example-games/main-street/MainStreetTiers';
+
+type CardFamily = 'business' | 'event' | 'upgrade';
+
+function familyFromCardId(cardId: string): CardFamily {
+  if (cardId.startsWith('biz-')) return 'business';
+  if (cardId.startsWith('evt-')) return 'event';
+  return 'upgrade';
+}
+
+const tier1Ids = TIER_DEFINITIONS['tier-1'].newCardIds;
+const counts: Record<CardFamily, number> = {
+  business: 0,
+  event: 0,
+  upgrade: 0,
+};
+
+for (const cardId of tier1Ids) {
+  counts[familyFromCardId(cardId)] += 1;
+}
+
+const baselineTotal = counts.business + counts.event + counts.upgrade;
+
+const baseline = {
+  source: 'Tier 1 baseline from example-games/main-street/MainStreetTiers.ts',
+  capturedAt: new Date().toISOString(),
+  perTier: {
+    tier1: {
+      ...counts,
+      total: baselineTotal,
+    },
+  },
+  totals: {
+    baselineTotal,
+    targetAtLeast: baselineTotal * 2,
+  },
+};
+
+const outputPath = resolve(process.cwd(), 'docs/main-street/card-catalog-baseline.json');
+writeFileSync(outputPath, `${JSON.stringify(baseline, null, 2)}\n`, 'utf-8');
+console.log(`Wrote ${outputPath}`);

--- a/tests/main-street/card-catalog-baseline.test.ts
+++ b/tests/main-street/card-catalog-baseline.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  createBusinessDeck,
+  createEventDeck,
+  createUpgradeDeck,
+} from '../../example-games/main-street/MainStreetCards';
+import { createSeededRng } from '../../src/core-engine';
+
+interface BaselineCatalog {
+  source: string;
+  capturedAt: string;
+  perTier: {
+    tier1: {
+      business: number;
+      event: number;
+      upgrade: number;
+      total: number;
+    };
+  };
+  totals: {
+    baselineTotal: number;
+    targetAtLeast: number;
+  };
+}
+
+function loadBaseline(): BaselineCatalog {
+  const baselinePath = resolve(process.cwd(), 'docs/main-street/card-catalog-baseline.json');
+  return JSON.parse(readFileSync(baselinePath, 'utf-8')) as BaselineCatalog;
+}
+
+function currentCatalogTotal(): number {
+  const rng = createSeededRng(123);
+  const businessCount = createBusinessDeck(1).length;
+  const eventCount = createEventDeck(1, undefined, rng, 1).length;
+  const upgradeCount = createUpgradeDeck(1).length;
+  return businessCount + eventCount + upgradeCount;
+}
+
+describe('Main Street card catalog baseline', () => {
+  it('contains machine-checkable baseline totals', () => {
+    const baseline = loadBaseline();
+    expect(baseline.source).toContain('Tier 1');
+    expect(baseline.perTier.tier1.total).toBe(
+      baseline.perTier.tier1.business + baseline.perTier.tier1.event + baseline.perTier.tier1.upgrade,
+    );
+    expect(baseline.totals.targetAtLeast).toBe(baseline.totals.baselineTotal * 2);
+  });
+
+  it('current card pool is at least 2x baseline', () => {
+    const baseline = loadBaseline();
+    expect(currentCatalogTotal()).toBeGreaterThanOrEqual(baseline.totals.targetAtLeast);
+  });
+});


### PR DESCRIPTION
## Summary
- add generator for Tier 1 baseline snapshot
- add baseline JSON with machine-checkable 2x target
- add unit test enforcing current pool >= 2x baseline

## Testing
- npx vitest run --project unit tests/main-street/card-catalog-baseline.test.ts