### PR TITLE
CG-0MP1QZ97R004SZFM: add expanded card manifest verification

### DIFF
--- a/docs/main-street/expanded-card-manifest.json
+++ b/docs/main-street/expanded-card-manifest.json
@@ -1,0 +1,73 @@
+{
+  "source": "Generated from MainStreetCards.ts and Tier 1 IDs from MainStreetTiers.ts",
+  "generatedAt": "2026-05-11T23:51:22.930Z",
+  "baselineTier1CardIds": [
+    "biz-bakery",
+    "biz-bookshop",
+    "biz-diner",
+    "biz-hardware",
+    "biz-park",
+    "evt-award",
+    "evt-festival",
+    "evt-inspection",
+    "evt-rainy",
+    "evt-tax",
+    "upg-bistro",
+    "upg-library",
+    "upg-patisserie"
+  ],
+  "expandedCardIds": {
+    "business": [
+      "biz-arcade",
+      "biz-barbershop",
+      "biz-boutique",
+      "biz-cafe",
+      "biz-cinema",
+      "biz-clinic",
+      "biz-florist",
+      "biz-food-truck",
+      "biz-gallery",
+      "biz-laundromat",
+      "biz-pawnshop",
+      "biz-spa"
+    ],
+    "event": [
+      "evt-block-party",
+      "evt-charity-drive",
+      "evt-construction",
+      "evt-food-critic",
+      "evt-grand-opening",
+      "evt-noise-complaint",
+      "evt-pipe-burst",
+      "evt-power-outage",
+      "evt-shoplifting",
+      "evt-vandalism",
+      "evt-viral-review",
+      "evt-wellness-fair"
+    ],
+    "upgrade": [
+      "upg-bread-factory",
+      "upg-designer-store",
+      "upg-drive-in",
+      "upg-dry-cleaners",
+      "upg-fast-food",
+      "upg-gaming-lounge",
+      "upg-garden",
+      "upg-garden-center",
+      "upg-gourmet-truck",
+      "upg-grand-bakehouse",
+      "upg-home-improvement",
+      "upg-imax",
+      "upg-luxury-retreat",
+      "upg-medical-center",
+      "upg-multiplex",
+      "upg-museum",
+      "upg-resort-spa",
+      "upg-restaurant",
+      "upg-roastery",
+      "upg-salon",
+      "upg-vintage-shop",
+      "upg-wellness-center"
+    ]
+  }
+}

--- a/scripts/generate-main-street-expanded-card-manifest.ts
+++ b/scripts/generate-main-street-expanded-card-manifest.ts
@@ -1,0 +1,37 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  createBusinessDeck,
+  createEventDeck,
+  createUpgradeDeck,
+} from '../example-games/main-street/MainStreetCards';
+import { TIER_DEFINITIONS } from '../example-games/main-street/MainStreetTiers';
+import { createSeededRng } from '../src/core-engine';
+
+function uniqueTemplateIds(ids: string[]): string[] {
+  return [...new Set(ids.map(id => id.replace(/-\d+$/, '')))].sort();
+}
+
+const baselineTier1CardIds = [...TIER_DEFINITIONS['tier-1'].newCardIds].sort();
+const baselineSet = new Set(baselineTier1CardIds);
+
+const rng = createSeededRng(42);
+const business = uniqueTemplateIds(createBusinessDeck(1).map(c => c.id));
+const event = uniqueTemplateIds(createEventDeck(1, undefined, rng, 1).map(c => c.id));
+const upgrade = uniqueTemplateIds(createUpgradeDeck(1).map(c => c.id));
+
+const manifest = {
+  source: 'Generated from MainStreetCards.ts and Tier 1 IDs from MainStreetTiers.ts',
+  generatedAt: new Date().toISOString(),
+  baselineTier1CardIds,
+  expandedCardIds: {
+    business: business.filter(id => !baselineSet.has(id)),
+    event: event.filter(id => !baselineSet.has(id)),
+    upgrade: upgrade.filter(id => !baselineSet.has(id)),
+  },
+};
+
+const output = resolve(process.cwd(), 'docs/main-street/expanded-card-manifest.json');
+writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+console.log(`Wrote ${output}`);

--- a/tests/main-street/card-manifest.test.ts
+++ b/tests/main-street/card-manifest.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  createBusinessDeck,
+  createEventDeck,
+  createUpgradeDeck,
+} from '../../example-games/main-street/MainStreetCards';
+import { createSeededRng } from '../../src/core-engine';
+
+interface ExpandedCardManifest {
+  baselineTier1CardIds: string[];
+  expandedCardIds: {
+    business: string[];
+    event: string[];
+    upgrade: string[];
+  };
+}
+
+function loadManifest(): ExpandedCardManifest {
+  const p = resolve(process.cwd(), 'docs/main-street/expanded-card-manifest.json');
+  return JSON.parse(readFileSync(p, 'utf-8')) as ExpandedCardManifest;
+}
+
+function allCurrentTemplateIds(): { business: string[]; event: string[]; upgrade: string[] } {
+  const rng = createSeededRng(42);
+  const business = createBusinessDeck(1).map(c => c.id.replace(/-\d+$/, ''));
+  const event = createEventDeck(1, undefined, rng, 1).map(c => c.id.replace(/-\d+$/, ''));
+  const upgrade = createUpgradeDeck(1).map(c => c.id.replace(/-\d+$/, ''));
+  return {
+    business: [...new Set(business)].sort(),
+    event: [...new Set(event)].sort(),
+    upgrade: [...new Set(upgrade)].sort(),
+  };
+}
+
+describe('Main Street expanded card manifest', () => {
+  it('tracks all non-baseline card templates by family', () => {
+    const manifest = loadManifest();
+    const current = allCurrentTemplateIds();
+
+    const baseline = new Set(manifest.baselineTier1CardIds);
+
+    const expectedBusiness = current.business.filter(id => !baseline.has(id)).sort();
+    const expectedEvent = current.event.filter(id => !baseline.has(id)).sort();
+    const expectedUpgrade = current.upgrade.filter(id => !baseline.has(id)).sort();
+
+    expect(manifest.expandedCardIds.business.slice().sort()).toEqual(expectedBusiness);
+    expect(manifest.expandedCardIds.event.slice().sort()).toEqual(expectedEvent);
+    expect(manifest.expandedCardIds.upgrade.slice().sort()).toEqual(expectedUpgrade);
+  });
+
+  it('expanded template count keeps total pool above 2x baseline', () => {
+    const manifest = loadManifest();
+    const baselineCount = manifest.baselineTier1CardIds.length;
+    const expandedCount =
+      manifest.expandedCardIds.business.length +
+      manifest.expandedCardIds.event.length +
+      manifest.expandedCardIds.upgrade.length;
+
+    expect(baselineCount + expandedCount).toBeGreaterThanOrEqual(baselineCount * 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add generator for expanded (non-Tier-1) Main Street card IDs
- add generated manifest grouped by business/event/upgrade
- add unit tests to keep manifest in sync and verify 2x threshold remains satisfied

## Testing
- npx vitest run --project unit tests/main-street/card-manifest.test.ts
- npx vitest run --project unit tests/main-street/expanded-card-pool.test.ts