### PR TITLE
CG-0MP1QZKGM0024T57: add Monte Carlo drift guardrails

### DIFF
--- a/docs/main-street/monte-carlo-baseline.json
+++ b/docs/main-street/monte-carlo-baseline.json
@@ -1,0 +1,11 @@
+{
+  "source": "Generated from MainStreetMonteCarlo.runMonteCarlo",
+  "generatedAt": "2026-05-11T23:58:08.168Z",
+  "seeds": 200,
+  "maxTurns": 25,
+  "strategy": "greedy",
+  "metrics": {
+    "winRate": 0.375,
+    "averageCoinsPerTurn": 1.3313735986450772
+  }
+}

--- a/example-games/main-street/MainStreetMonteCarlo.ts
+++ b/example-games/main-street/MainStreetMonteCarlo.ts
@@ -9,6 +9,7 @@ export interface MonteCarloRunSummary {
   result: 'win' | 'loss';
   endReason: string;
   finalScore: number;
+  finalCoins: number;
   turns: number;
   turnWhenGridHalf: number | null;
   turnWhenGridFull: number | null;
@@ -22,6 +23,7 @@ export interface MonteCarloMetrics {
   winRate: number;
   medianScore: number;
   averageScore: number;
+  averageCoinsPerTurn: number;
   averageTurns: number;
   averageNoActionTurns: number;
   averageTurnWhenGridHalf: number | null;
@@ -209,6 +211,7 @@ function runSeed(seed: string, maxTurns: number, strategy: MonteCarloStrategy): 
     result,
     endReason,
     finalScore: state.finalScore,
+    finalCoins: state.resourceBank.coins,
     turns,
     turnWhenGridHalf,
     turnWhenGridFull,
@@ -242,6 +245,9 @@ export function runMonteCarlo(options: RunMonteCarloOptions): MonteCarloResult {
     winRate: runs.length > 0 ? wins / runs.length : 0,
     medianScore: median(runs.map(run => run.finalScore)),
     averageScore: average(runs.map(run => run.finalScore)),
+    averageCoinsPerTurn: average(
+      runs.map(run => (run.turns > 0 ? run.finalCoins / run.turns : 0)),
+    ),
     averageTurns: average(runs.map(run => run.turns)),
     averageNoActionTurns: average(runs.map(run => run.noActionTurns)),
     averageTurnWhenGridHalf: average(
@@ -274,6 +280,7 @@ export function toCsv(runs: readonly MonteCarloRunSummary[]): string {
     'result',
     'endReason',
     'finalScore',
+    'finalCoins',
     'turns',
     'turnWhenGridHalf',
     'turnWhenGridFull',
@@ -284,6 +291,7 @@ export function toCsv(runs: readonly MonteCarloRunSummary[]): string {
     run.result,
     run.endReason,
     String(run.finalScore),
+    String(run.finalCoins),
     String(run.turns),
     run.turnWhenGridHalf === null ? '' : String(run.turnWhenGridHalf),
     run.turnWhenGridFull === null ? '' : String(run.turnWhenGridFull),

--- a/scripts/generate-main-street-monte-baseline.ts
+++ b/scripts/generate-main-street-monte-baseline.ts
@@ -1,0 +1,27 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { runMonteCarlo } from '../example-games/main-street/MainStreetMonteCarlo';
+
+const seeds = 200;
+const maxTurns = 25;
+const strategy = 'greedy' as const;
+
+const runSeeds = Array.from({ length: seeds }, (_, i) => `mc-balance-${i}`);
+const result = runMonteCarlo({ seeds: runSeeds, maxTurns, strategy });
+
+const baseline = {
+  source: 'Generated from MainStreetMonteCarlo.runMonteCarlo',
+  generatedAt: new Date().toISOString(),
+  seeds,
+  maxTurns,
+  strategy,
+  metrics: {
+    winRate: result.metrics.winRate,
+    averageCoinsPerTurn: result.metrics.averageCoinsPerTurn,
+  },
+};
+
+const outputPath = resolve(process.cwd(), 'docs/main-street/monte-carlo-baseline.json');
+writeFileSync(outputPath, `${JSON.stringify(baseline, null, 2)}\n`, 'utf-8');
+console.log(`Wrote ${outputPath}`);

--- a/tests/main-street/monte-carlo-guardrails.test.ts
+++ b/tests/main-street/monte-carlo-guardrails.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { runMonteCarlo } from '../../example-games/main-street/MainStreetMonteCarlo';
+
+interface MonteBaseline {
+  seeds: number;
+  maxTurns: number;
+  strategy: 'greedy' | 'random' | 'market-greedy' | 'demo-greedy';
+  metrics: {
+    winRate: number;
+    averageCoinsPerTurn: number;
+  };
+}
+
+function loadBaseline(): MonteBaseline {
+  const pathToBaseline = resolve(process.cwd(), 'docs/main-street/monte-carlo-baseline.json');
+  return JSON.parse(readFileSync(pathToBaseline, 'utf-8')) as MonteBaseline;
+}
+
+describe('Main Street Monte Carlo guardrails for expanded pool', () => {
+  it('stays within configured win-rate and coin-per-turn drift bounds', () => {
+    const baseline = loadBaseline();
+    const seeds = Array.from({ length: baseline.seeds }, (_, i) => `mc-balance-${i}`);
+
+    const result = runMonteCarlo({
+      seeds,
+      maxTurns: baseline.maxTurns,
+      strategy: baseline.strategy,
+    });
+
+    const starvationOrIncompleteRuns = result.runs.filter(
+      run => run.endReason === 'max_turns_cap' || run.turns >= baseline.maxTurns,
+    );
+    expect(starvationOrIncompleteRuns).toHaveLength(0);
+
+    const winRateDelta = Math.abs(result.metrics.winRate - baseline.metrics.winRate);
+    expect(winRateDelta).toBeLessThanOrEqual(0.10);
+
+    const coinPerTurnDelta = Math.abs(
+      result.metrics.averageCoinsPerTurn - baseline.metrics.averageCoinsPerTurn,
+    );
+    const allowedCoinPerTurnDelta = baseline.metrics.averageCoinsPerTurn * 0.15;
+    expect(coinPerTurnDelta).toBeLessThanOrEqual(allowedCoinPerTurnDelta);
+  });
+});


### PR DESCRIPTION
## Summary
- extend Monte Carlo metrics with averageCoinsPerTurn and per-run finalCoins
- add deterministic baseline generator and committed baseline file
- add guardrail test for completion/no-starvation + drift bounds:
  - win-rate delta <= 10%
  - average coins-per-turn delta <= 15%

## Testing
- npx vitest run --project unit tests/main-street/monte-carlo-guardrails.test.ts tests/main-street/monte-carlo-balance.test.ts tests/main-street/market.integration.test.ts