### PR TITLE
CG-0MP1VO5FM008LB5Z: unlock full expanded catalog through tiers

### DIFF
--- a/docs/main-street/card-catalog-baseline.json
+++ b/docs/main-street/card-catalog-baseline.json
@@ -1,16 +1,16 @@
 {
   "source": "Tier 1 baseline from example-games/main-street/MainStreetTiers.ts",
-  "capturedAt": "2026-05-11T23:24:23.737Z",
+  "capturedAt": "2026-05-12T00:15:46.437Z",
   "perTier": {
     "tier1": {
-      "business": 5,
-      "event": 5,
-      "upgrade": 3,
-      "total": 13
+      "business": 7,
+      "event": 6,
+      "upgrade": 5,
+      "total": 18
     }
   },
   "totals": {
-    "baselineTotal": 13,
-    "targetAtLeast": 26
+    "baselineTotal": 18,
+    "targetAtLeast": 36
   }
 }

--- a/docs/main-street/card-catalog.md
+++ b/docs/main-street/card-catalog.md
@@ -19,12 +19,12 @@ This document lists every card template in the Main Street card pool, organised 
 
 | Snapshot | Business | Event | Upgrade | Total templates |
 |---|---:|---:|---:|---:|
-| Tier 1 baseline (`docs/main-street/card-catalog-baseline.json`) | 5 | 5 | 3 | 13 |
+| Tier 1 baseline (`docs/main-street/card-catalog-baseline.json`) | 7 | 6 | 5 | 18 |
 | Current catalog (`MainStreetCards.ts`) | 17 | 17 | 25 | 59 |
-| Net increase | +12 | +12 | +22 | +46 |
+| Net increase | +10 | +11 | +20 | +41 |
 
-- 2x target from baseline: `>= 26` templates
-- Current total: `59` templates (`4.54x` baseline)
+- 2x target from baseline: `>= 36` templates
+- Current total: `59` templates (`3.28x` baseline)
 - Non-baseline card IDs are tracked in `docs/main-street/expanded-card-manifest.json`
 
 ### Guidance: adding more cards safely

--- a/docs/main-street/expanded-card-manifest.json
+++ b/docs/main-street/expanded-card-manifest.json
@@ -1,20 +1,25 @@
 {
   "source": "Generated from MainStreetCards.ts and Tier 1 IDs from MainStreetTiers.ts",
-  "generatedAt": "2026-05-11T23:51:22.930Z",
+  "generatedAt": "2026-05-12T00:15:46.868Z",
   "baselineTier1CardIds": [
     "biz-bakery",
     "biz-bookshop",
     "biz-diner",
     "biz-hardware",
+    "biz-laundromat",
     "biz-park",
+    "biz-pawnshop",
     "evt-award",
     "evt-festival",
+    "evt-grand-opening",
     "evt-inspection",
     "evt-rainy",
     "evt-tax",
     "upg-bistro",
+    "upg-garden",
     "upg-library",
-    "upg-patisserie"
+    "upg-patisserie",
+    "upg-vintage-shop"
   ],
   "expandedCardIds": {
     "business": [
@@ -27,8 +32,6 @@
       "biz-florist",
       "biz-food-truck",
       "biz-gallery",
-      "biz-laundromat",
-      "biz-pawnshop",
       "biz-spa"
     ],
     "event": [
@@ -36,7 +39,6 @@
       "evt-charity-drive",
       "evt-construction",
       "evt-food-critic",
-      "evt-grand-opening",
       "evt-noise-complaint",
       "evt-pipe-burst",
       "evt-power-outage",
@@ -52,7 +54,6 @@
       "upg-dry-cleaners",
       "upg-fast-food",
       "upg-gaming-lounge",
-      "upg-garden",
       "upg-garden-center",
       "upg-gourmet-truck",
       "upg-grand-bakehouse",
@@ -66,7 +67,6 @@
       "upg-restaurant",
       "upg-roastery",
       "upg-salon",
-      "upg-vintage-shop",
       "upg-wellness-center"
     ]
   }

--- a/docs/main-street/prd-milestone-2.md
+++ b/docs/main-street/prd-milestone-2.md
@@ -170,13 +170,15 @@ Run N+1 starts with expanded card pool
 | 4 | District | >= 10 | Any 3 (incl. 1 cross-cutting/placement) | 1 (Arcade) | 1 (Block Party) | 1 (Bread Factory) | 22 |
 | 5 | Landmark | >= 12 | Diversified challenge | 1 (Day Spa) | 1 (Charity Drive) | 1 (Grand Bakehouse) | 25 |
 
-**Total new cards across Tiers 2-5: 12** (4 Business + 4 Event + 4 Upgrade)
+**Total new cards across Tiers 2-5: 41** (10 Business + 11 Event + 20 Upgrade)
 
-### 2.7 Remaining M2 Cards
+> Update note: tier distribution was expanded in follow-up work item CG-0MP1VO5FM008LB5Z so campaign progression now covers the full 59-template catalog, with a 5-card expanded sample available in Tier 1.
 
-The following M2 cards are **not tier-gated** and will be included in Tier 1 once the full M2 content milestone is complete. They are listed here for completeness and to clarify that tier-gating applies only to the 12 cards specified above.
+### 2.7 Historical note (superseded)
 
-These cards are part of the broader M2 content expansion (parent work item CG-0MM4REC2Z0GS2YKT) and will be added to Tier 1 as part of separate M2 content work items, not this meta-progression spec.
+This section originally tracked cards that were not tier-gated. It is now superseded by follow-up work item CG-0MP1VO5FM008LB5Z, which updated progression so the full expanded catalog is tier-gated and reachable through campaign unlocks.
+
+The list below is retained as historical context for prior milestone discussions.
 
 | Type | Remaining M2 Cards (added to Tier 1 pool) |
 |------|--------------------------------------------|
@@ -786,9 +788,9 @@ The following items are explicitly excluded from this spec:
 
 | Snapshot | Business | Event | Upgrade | Total templates |
 |---|---:|---:|---:|---:|
-| Tier 1 baseline | 5 | 5 | 3 | 13 |
+| Tier 1 baseline | 7 | 6 | 5 | 18 |
 | Current catalog | 17 | 17 | 25 | 59 |
-| Net increase | +12 | +12 | +22 | +46 |
+| Net increase | +10 | +11 | +20 | +41 |
 
 Verification artifacts:
 - `docs/main-street/card-catalog-baseline.json`

--- a/example-games/main-street/MainStreetTiers.ts
+++ b/example-games/main-street/MainStreetTiers.ts
@@ -40,6 +40,7 @@ export interface TierDefinition {
 // ── Tier 1 Card IDs (M1 Baseline) ──────────────────────────
 
 const TIER_1_CARD_IDS: string[] = [
+  // M1 baseline (13)
   // Business (5)
   'biz-bakery',
   'biz-diner',
@@ -56,38 +57,74 @@ const TIER_1_CARD_IDS: string[] = [
   'upg-patisserie',
   'upg-bistro',
   'upg-library',
+
+  // Early expanded sample (~10% of expanded set => 5 cards)
+  'biz-pawnshop',
+  'biz-laundromat',
+  'evt-grand-opening',
+  'upg-garden',
+  'upg-vintage-shop',
 ];
 
 // ── Tier 2 Card IDs (Rising Street) ────────────────────────
 
 const TIER_2_NEW_CARD_IDS: string[] = [
-  'biz-pawnshop',
-  'biz-laundromat',
-  'evt-grand-opening',
+  'biz-boutique',
+  'biz-cafe',
+  'biz-arcade',
+  'evt-wellness-fair',
+  'evt-block-party',
+  'upg-bread-factory',
+  'upg-designer-store',
+  'upg-drive-in',
+  'upg-dry-cleaners',
+  'upg-fast-food',
 ];
 
 // ── Tier 3 Card IDs (Neighborhood) ─────────────────────────
 
 const TIER_3_NEW_CARD_IDS: string[] = [
-  'biz-cafe',
-  'evt-wellness-fair',
-  'upg-garden',
+  'biz-barbershop',
+  'biz-cinema',
+  'biz-food-truck',
+  'evt-charity-drive',
+  'evt-construction',
+  'evt-food-critic',
+  'upg-gaming-lounge',
+  'upg-imax',
+  'upg-garden-center',
+  'upg-gourmet-truck',
 ];
 
 // ── Tier 4 Card IDs (District) ─────────────────────────────
 
 const TIER_4_NEW_CARD_IDS: string[] = [
-  'biz-arcade',
-  'evt-block-party',
-  'upg-bread-factory',
+  'biz-gallery',
+  'biz-florist',
+  'biz-clinic',
+  'evt-noise-complaint',
+  'evt-pipe-burst',
+  'evt-power-outage',
+  'upg-grand-bakehouse',
+  'upg-home-improvement',
+  'upg-medical-center',
+  'upg-museum',
 ];
 
 // ── Tier 5 Card IDs (Landmark) ─────────────────────────────
 
 const TIER_5_NEW_CARD_IDS: string[] = [
   'biz-spa',
-  'evt-charity-drive',
-  'upg-grand-bakehouse',
+  'evt-shoplifting',
+  'evt-vandalism',
+  'evt-viral-review',
+  'upg-luxury-retreat',
+  'upg-multiplex',
+  'upg-resort-spa',
+  'upg-restaurant',
+  'upg-roastery',
+  'upg-salon',
+  'upg-wellness-center',
 ];
 
 // ── Challenge Condition Helpers ─────────────────────────────

--- a/tests/main-street/meta-progression.test.ts
+++ b/tests/main-street/meta-progression.test.ts
@@ -155,19 +155,19 @@ describe('Meta-Progression System', () => {
       }
     });
 
-    it('Tier 1 has 13 cards (5 biz + 5 evt + 3 upg)', () => {
-      expect(TIER_DEFINITIONS['tier-1'].newCardIds).toHaveLength(13);
-      expect(TIER_DEFINITIONS['tier-1'].cumulativeCardIds).toHaveLength(13);
+    it('Tier 1 has baseline plus early expanded sample (18 cards total)', () => {
+      expect(TIER_DEFINITIONS['tier-1'].newCardIds).toHaveLength(18);
+      expect(TIER_DEFINITIONS['tier-1'].cumulativeCardIds).toHaveLength(18);
     });
 
-    it('each subsequent tier adds exactly 3 new cards', () => {
+    it('each subsequent tier adds additional cards', () => {
       for (let i = 2; i <= 5; i++) {
-        expect(TIER_DEFINITIONS[`tier-${i}`].newCardIds).toHaveLength(3);
+        expect(TIER_DEFINITIONS[`tier-${i}`].newCardIds.length).toBeGreaterThan(0);
       }
     });
 
-    it('Tier 5 cumulative pool has 25 cards (13 + 3*4)', () => {
-      expect(TIER_DEFINITIONS['tier-5'].cumulativeCardIds).toHaveLength(25);
+    it('Tier 5 cumulative pool covers full catalog (59 templates)', () => {
+      expect(TIER_DEFINITIONS['tier-5'].cumulativeCardIds).toHaveLength(59);
     });
 
     it('cumulative card IDs are actually cumulative', () => {
@@ -689,7 +689,7 @@ describe('Meta-Progression System', () => {
       }
     });
 
-    it('Tier 5 pool yields all 25 unique template IDs across all deck builders', () => {
+    it('Tier 5 pool yields all 59 unique template IDs across all deck builders', () => {
       const tier5CardIds = TIER_DEFINITIONS['tier-5'].cumulativeCardIds;
 
       const bizDeck = createBusinessDeck(1, tier5CardIds);
@@ -702,7 +702,7 @@ describe('Meta-Progression System', () => {
         ...upgDeck.map((c) => c.id.replace(/-\d+$/, '')),
       ]);
 
-      expect(allBaseIds.size).toBe(25);
+      expect(allBaseIds.size).toBe(59);
     });
   });
 
@@ -717,10 +717,10 @@ describe('Meta-Progression System', () => {
       expect(campaign.schemaVersion).toBe(2);
     });
 
-    it('default campaign has tier-1 unlocked with 13 card IDs', () => {
+    it('default campaign has tier-1 unlocked with 18 card IDs', () => {
       const campaign = createDefaultCampaignProgress();
       expect(campaign.unlockedTiers).toEqual(['tier-1']);
-      expect(campaign.unlockedCardIds).toHaveLength(13);
+      expect(campaign.unlockedCardIds).toHaveLength(18);
       expect(campaign.milestoneHistory).toEqual([]);
     });
 
@@ -1062,18 +1062,18 @@ describe('Meta-Progression System', () => {
   describe('deriveUnlockedCardIds', () => {
     it('returns tier-1 cards for ["tier-1"]', () => {
       const ids = deriveUnlockedCardIds(['tier-1']);
-      expect(ids).toHaveLength(13);
-      expect(new Set(ids).size).toBe(13); // no duplicates
+      expect(ids).toHaveLength(18);
+      expect(new Set(ids).size).toBe(18); // no duplicates
     });
 
     it('returns cumulative cards for ["tier-1", "tier-2"]', () => {
       const ids = deriveUnlockedCardIds(['tier-1', 'tier-2']);
-      expect(ids).toHaveLength(16); // 13 + 3
+      expect(ids).toHaveLength(28); // 18 + 10
     });
 
-    it('returns all 25 cards for all 5 tiers', () => {
+    it('returns all 59 cards for all 5 tiers', () => {
       const ids = deriveUnlockedCardIds(['tier-1', 'tier-2', 'tier-3', 'tier-4', 'tier-5']);
-      expect(ids).toHaveLength(25);
+      expect(ids).toHaveLength(59);
     });
 
     it('handles empty array', () => {
@@ -1083,7 +1083,7 @@ describe('Meta-Progression System', () => {
 
     it('ignores unknown tier IDs gracefully', () => {
       const ids = deriveUnlockedCardIds(['tier-1', 'tier-99']);
-      expect(ids).toHaveLength(13); // only tier-1 cards
+      expect(ids).toHaveLength(18); // only tier-1 cards
     });
 
     it('does not produce duplicates even if tiers are listed twice', () => {
@@ -1443,7 +1443,7 @@ describe('Meta-Progression UI Logic', () => {
       const cardNames = tier2Def.newCardIds.map(
         (id) => CARD_TEMPLATE_NAMES.get(id) ?? id,
       );
-      expect(cardNames.length).toBe(3);
+      expect(cardNames.length).toBe(TIER_DEFINITIONS['tier-2'].newCardIds.length);
       // All names should be resolved (not fallback to IDs)
       for (const name of cardNames) {
         expect(name).not.toMatch(/^biz-|^evt-|^upg-/);

--- a/tests/main-street/tier-catalog-coverage.test.ts
+++ b/tests/main-street/tier-catalog-coverage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { createBusinessDeck, createEventDeck, createUpgradeDeck } from '../../example-games/main-street/MainStreetCards';
+import { TIER_DEFINITIONS } from '../../example-games/main-street/MainStreetTiers';
+import { createSeededRng } from '../../src/core-engine';
+
+function allTemplateIds(): Set<string> {
+  const rng = createSeededRng(42);
+  const business = createBusinessDeck(1).map(c => c.id.replace(/-\d+$/, ''));
+  const events = createEventDeck(1, undefined, rng, 1).map(c => c.id.replace(/-\d+$/, ''));
+  const upgrades = createUpgradeDeck(1).map(c => c.id.replace(/-\d+$/, ''));
+  return new Set([...business, ...events, ...upgrades]);
+}
+
+describe('Main Street tier catalog coverage', () => {
+  it('tier-5 cumulative card IDs cover the full catalog', () => {
+    const all = allTemplateIds();
+    const tier5 = new Set(TIER_DEFINITIONS['tier-5'].cumulativeCardIds);
+
+    expect(tier5.size).toBe(all.size);
+    for (const id of all) {
+      expect(tier5.has(id), `missing template in tier progression: ${id}`).toBe(true);
+    }
+  });
+
+  it('tier-1 includes a small expanded sample (~10% of expanded set = 5 cards)', () => {
+    const all = allTemplateIds();
+    const tier1 = new Set(TIER_DEFINITIONS['tier-1'].newCardIds);
+
+    const expanded = [...all].filter(id => !tier1.has(id));
+    // expanded cards in tier1 = cards in tier1 that are outside original M1 baseline (13 fixed IDs)
+    const baselineM1 = new Set([
+      'biz-bakery', 'biz-diner', 'biz-bookshop', 'biz-park', 'biz-hardware',
+      'evt-festival', 'evt-rainy', 'evt-tax', 'evt-award', 'evt-inspection',
+      'upg-patisserie', 'upg-bistro', 'upg-library',
+    ]);
+    const expandedCountInTier1 = TIER_DEFINITIONS['tier-1'].newCardIds.filter(id => !baselineM1.has(id)).length;
+
+    expect(expanded.length).toBeGreaterThan(0);
+    expect(expandedCountInTier1).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- rebalance Main Street tier card assignments so campaign progression covers all 59 card templates
- include 5 expanded cards in Tier 1 (~10% early sample) for immediate variety
- add dedicated tier coverage tests and update meta-progression expectations
- regenerate baseline/manifest artifacts and update docs summaries

## Testing
- npx vitest run --project unit tests/main-street/tier-catalog-coverage.test.ts tests/main-street/meta-progression.test.ts tests/main-street/card-catalog-baseline.test.ts tests/main-street/card-manifest.test.ts tests/main-street/expanded-card-integration.test.ts
- npm test
- npm run build