### PR TITLE
CG-0MP28ZCOT002PCE9: hide Main Street tooltip after card play

### DIFF
--- a/example-games/main-street/scenes/MainStreetTurnController.ts
+++ b/example-games/main-street/scenes/MainStreetTurnController.ts
@@ -191,6 +191,9 @@ export class MainStreetTurnController {
     const s = this.scene;
     if (s.uiPhase !== 'placing-business' || !s.pendingBusinessCard) return;
 
+    // Ensure stale hover tooltip is cleared when a card is played.
+    s.tooltipManager?.hide();
+
     const sourceIndex = s.pendingBusinessSourceIndex;
     const pendingCardId = s.pendingBusinessCard.id;
     const pendingCardName = s.pendingBusinessCard.name;
@@ -239,6 +242,9 @@ export class MainStreetTurnController {
   public onEventCardClick(card: EventCard): void {
     const s = this.scene;
     if (s.uiPhase !== 'market') return;
+
+    // Ensure stale hover tooltip is cleared when a card is played.
+    s.tooltipManager?.hide();
 
     s.selectMarketCardById(card.id);
 
@@ -318,6 +324,9 @@ export class MainStreetTurnController {
   public onUpgradeCardClick(card: UpgradeCard): void {
     const s = this.scene;
     if (s.uiPhase !== 'market') return;
+
+    // Ensure stale hover tooltip is cleared when a card is played.
+    s.tooltipManager?.hide();
 
     s.selectMarketCardById(card.id);
 

--- a/tests/main-street/MainStreetScene.browser.test.ts
+++ b/tests/main-street/MainStreetScene.browser.test.ts
@@ -280,6 +280,9 @@ describe('MainStreetScene browser tests', () => {
       );
       expect(business).toBeTruthy();
 
+      const hideSpy = vi.spyOn(scene.tooltipManager, 'hide');
+      scene.tooltipManager?.show('tmp tooltip', 100, 100);
+
       const beforeBusinessAnimCount = scene.getTransferAnimationCountForTest();
       scene.onBusinessCardClick(business);
       scene.onSlotClick(targetSlot);
@@ -294,6 +297,7 @@ describe('MainStreetScene browser tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 2000));
       expect(state.streetGrid[targetSlot]?.id).toBe(business.id);
       expect(scene.getHiddenTransferSourceCardCountForTest()).toBe(0);
+      expect(hideSpy).toHaveBeenCalled();
 
       const eventCard = state.market.investments.find((card: any) =>
         card && card.family === 'event' && canPurchaseEvent(state, card.id).legal,


### PR DESCRIPTION
## Summary
- hide tooltip when business/event/upgrade card play actions begin
- add browser regression assertion proving tooltip hide is triggered during card play flow

## Testing
- npx vitest run --project browser tests/main-street/MainStreetScene.browser.test.ts -t "only materializes purchased cards"
- npm test
- npm run build